### PR TITLE
MULE-12327: ArtifactClassLoaderRunner - Application URLs are also

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,11 +115,11 @@
         </dependency>
 
         <!-- Tests -->
-        <!-- MULE-9702 Remove once tests are migrated-->
         <dependency>
-            <groupId>org.mule.tests</groupId>
-            <artifactId>mule-tests-unit</artifactId>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
             <version>${mule.version}</version>
+            <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerValidateCertificateTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerValidateCertificateTestCase.java
@@ -8,8 +8,8 @@ package org.mule.test.http.functional.listener;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mule.functional.api.component.FlowAssert.verify;
 import static org.mule.runtime.http.api.HttpConstants.Method.POST;
+import static org.mule.tck.processor.FlowAssert.verify;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 
 import org.mule.runtime.api.tls.TlsContextFactory;

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
@@ -29,7 +29,8 @@ import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERRORS;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERROR_HANDLING;
 
 import io.qameta.allure.Stories;
-import org.mule.functional.junit4.FlowRunner;
+
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.functional.junit4.rules.ExpectedError;
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.util.concurrent.Latch;

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestFollowRedirectsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestFollowRedirectsTestCase.java
@@ -7,10 +7,12 @@
 package org.mule.test.http.functional.requester;
 
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
+
+import org.mule.functional.api.flow.FlowRunner;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.mule.functional.junit4.FlowRunner;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.core.api.Event;
 

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestKeepAliveTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestKeepAliveTestCase.java
@@ -17,7 +17,7 @@ import static org.mule.runtime.http.api.HttpHeaders.Values.CLOSE;
 import static org.mule.runtime.http.api.HttpHeaders.Values.KEEP_ALIVE;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import org.mule.extension.http.api.HttpRequestAttributes;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.runtime.api.util.MultiMap;
 
 import org.junit.Test;

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestPartsTypeTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestPartsTypeTestCase.java
@@ -9,14 +9,13 @@ package org.mule.test.http.functional.requester;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mule.functional.api.component.FlowAssert.verify;
 import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
 import static org.mule.runtime.api.message.Message.builder;
 import static org.mule.runtime.api.metadata.MediaType.JSON;
+import static org.mule.tck.processor.FlowAssert.verify;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.MULTIPART;
 
-import io.qameta.allure.Issue;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.message.MultiPartPayload;
 import org.mule.runtime.core.api.Event;
@@ -32,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
 import io.qameta.allure.Story;
 
 @Feature(HTTP_EXTENSION)


### PR DESCRIPTION
including transitive dependencies from filter ones
* Cleanup test artifact dependencies so no unwanted transitive
dependencies en up in the APP classloader for tests