### PR TITLE
MULE-13363: Allow access to session properties from privileged API

### DIFF
--- a/src/main/java/org/mule/extension/http/internal/listener/HttpListener.java
+++ b/src/main/java/org/mule/extension/http/internal/listener/HttpListener.java
@@ -18,7 +18,6 @@ import static org.mule.extension.http.internal.listener.HttpRequestToResult.tran
 import static org.mule.runtime.api.component.ComponentIdentifier.builder;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.api.metadata.DataType.STRING;
-import static org.mule.runtime.core.api.InternalEvent.setCurrentEvent;
 import static org.mule.runtime.core.api.exception.Errors.ComponentIdentifiers.Handleable.SECURITY;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.util.SystemUtils.getDefaultEncoding;
@@ -27,6 +26,7 @@ import static org.mule.runtime.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.getReasonPhraseForStatusCode;
 import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.extension.http.api.HttpListenerResponseAttributes;
 import org.mule.extension.http.api.HttpRequestAttributes;
 import org.mule.extension.http.api.HttpResponseAttributes;
@@ -332,8 +332,6 @@ public class HttpListener extends Source<InputStream, HttpRequestAttributes> {
         } catch (RuntimeException e) {
           LOGGER.warn("Exception occurred processing request:", e);
           sendErrorResponse(INTERNAL_SERVER_ERROR, SERVER_PROBLEM, responseCallback);
-        } finally {
-          setCurrentEvent(null);
         }
       }
 

--- a/src/test/java/org/mule/test/http/functional/BasicHttpTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/BasicHttpTestCase.java
@@ -17,7 +17,7 @@ import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import org.mule.extension.http.api.HttpRequestAttributes;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -44,7 +44,7 @@ public class BasicHttpTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void sendsRequest() throws Exception {
-    InternalEvent response = flowRunner("client").withPayload("PEPE").run();
+    BaseEvent response = flowRunner("client").withPayload("PEPE").run();
     assertThat(response.getMessage().getPayload().getValue(), is(DEFAULT_RESPONSE));
     assertThat(method, is("GET"));
     assertThat(headers.get("X-Custom"), contains("custom-value"));
@@ -78,7 +78,7 @@ public class BasicHttpTestCase extends AbstractHttpRequestTestCase {
   protected static class RequestCheckerMessageProcessor implements Processor {
 
     @Override
-    public InternalEvent process(InternalEvent event) throws MuleException {
+    public BaseEvent process(BaseEvent event) throws MuleException {
       Message message = event.getMessage();
       Object payload = message.getPayload().getValue();
       assertThat(payload, is(notNullValue()));

--- a/src/test/java/org/mule/test/http/functional/HttpHeaderCaseTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/HttpHeaderCaseTestCase.java
@@ -14,7 +14,7 @@ import static org.mule.runtime.http.api.HttpHeaders.Names.CONTENT_TYPE;
 import static org.mule.runtime.http.api.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import org.mule.extension.http.api.HttpResponseAttributes;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.junit4.rule.SystemProperty;
 
@@ -44,7 +44,7 @@ public class HttpHeaderCaseTestCase extends AbstractHttpTestCase {
   @Description("Sets up a listener that returns form data and a requester that triggers it, all while preserving the headers name case. That way "
       + "we make sure the Host, Content-Type and other headers are handled correctly by both listener and requester.")
   public void worksPreservingHeaders() throws Exception {
-    InternalEvent response = runFlow("client");
+    BaseEvent response = runFlow("client");
     assertThat(response.getMessage(), hasPayload(equalTo("CustomValue=value")));
     HttpResponseAttributes attributes = (HttpResponseAttributes) response.getMessage().getAttributes().getValue();
     assertThat(attributes.getHeaders().get(CONTENT_TYPE), is(APPLICATION_X_WWW_FORM_URLENCODED.toRfcString()));

--- a/src/test/java/org/mule/test/http/functional/HttpRequestRecipientListTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/HttpRequestRecipientListTestCase.java
@@ -10,7 +10,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.internal.message.InternalMessage;
 import org.mule.tck.junit4.rule.DynamicPort;
 
@@ -38,7 +38,7 @@ public class HttpRequestRecipientListTestCase extends AbstractHttpTestCase {
 
   @Test
   public void recipientListWithHttpUrlsWithResponse() throws Exception {
-    final InternalEvent response = flowRunner("recipientListFlow").withPayload(TEST_MESSAGE)
+    final BaseEvent response = flowRunner("recipientListFlow").withPayload(TEST_MESSAGE)
         .withInboundProperty("urls", new String[] {getUrlForPort(port1), getUrlForPort(port2), getUrlForPort(port3)}).run();
 
     assertThat(response, notNullValue());

--- a/src/test/java/org/mule/test/http/functional/HttpStreamingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/HttpStreamingTestCase.java
@@ -19,7 +19,7 @@ import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.STREAMING
 import org.mule.extension.http.api.HttpResponseAttributes;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.tck.junit4.rule.DynamicPort;
 
@@ -60,7 +60,7 @@ public class HttpStreamingTestCase extends AbstractHttpTestCase {
 
   @Test
   public void requesterStreams() throws Exception {
-    InternalEvent response = flowRunner("client").run();
+    BaseEvent response = flowRunner("client").run();
     stop.set(true);
     assertThat(response.getMessage(), hasAttributes(instanceOf(HttpResponseAttributes.class)));
     assertThat(response.getMessage().getPayload().getValue(), instanceOf(CursorStreamProvider.class));
@@ -84,7 +84,7 @@ public class HttpStreamingTestCase extends AbstractHttpTestCase {
   protected static class StoppableInputStreamProcessor implements Processor {
 
     @Override
-    public InternalEvent process(InternalEvent event) throws MuleException {
+    public BaseEvent process(BaseEvent event) throws MuleException {
       InputStream inputStream = new InputStream() {
 
         @Override
@@ -96,7 +96,7 @@ public class HttpStreamingTestCase extends AbstractHttpTestCase {
           }
         }
       };
-      return InternalEvent.builder(event).message(of(inputStream)).build();
+      return BaseEvent.builder(event).message(of(inputStream)).build();
     }
 
   }

--- a/src/test/java/org/mule/test/http/functional/listener/AbstractHttpListenerErrorHandlingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/AbstractHttpListenerErrorHandlingTestCase.java
@@ -16,7 +16,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -81,7 +81,7 @@ public abstract class AbstractHttpListenerErrorHandlingTestCase extends Abstract
     public static boolean passed = false;
 
     @Override
-    public InternalEvent process(InternalEvent event) throws MuleException {
+    public BaseEvent process(BaseEvent event) throws MuleException {
       passed = true;
       return event;
     }

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerCustomTlsConfigMultipleKeysTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerCustomTlsConfigMultipleKeysTestCase.java
@@ -10,8 +10,9 @@ package org.mule.test.http.functional.listener;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.exception.MessagingException;
-import org.mule.runtime.core.api.InternalEvent;
 import org.mule.test.http.functional.AbstractHttpTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 
@@ -32,7 +33,7 @@ public class HttpListenerCustomTlsConfigMultipleKeysTestCase extends AbstractHtt
 
   @Test
   public void acceptsConnectionWithValidCertificate() throws Exception {
-    InternalEvent event = flowRunner("testFlowClientWithCertificate").withPayload(TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("testFlowClientWithCertificate").withPayload(TEST_MESSAGE).run();
     assertThat(event.getMessage().getPayload().getValue(), equalTo(TEST_MESSAGE));
   }
 

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerCustomTlsConfigTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerCustomTlsConfigTestCase.java
@@ -10,7 +10,8 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.HTTPS;
-import org.mule.runtime.core.api.InternalEvent;
+
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.test.http.functional.AbstractHttpTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 
@@ -39,7 +40,7 @@ public class HttpListenerCustomTlsConfigTestCase extends AbstractHttpTestCase {
 
   @Test
   public void customTlsGlobalContext() throws Exception {
-    final InternalEvent res = flowRunner("testFlowGlobalContextClient")
+    final BaseEvent res = flowRunner("testFlowGlobalContextClient")
         .withVariable("port", port1.getNumber())
         .withPayload("data")
         .run();
@@ -48,7 +49,7 @@ public class HttpListenerCustomTlsConfigTestCase extends AbstractHttpTestCase {
 
   @Test
   public void customTlsNestedContext() throws Exception {
-    final InternalEvent res = flowRunner("testFlowNestedContextClient")
+    final BaseEvent res = flowRunner("testFlowNestedContextClient")
         .withVariable("port", port2.getNumber())
         .withPayload("data")
         .run();

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerDisableTimeoutsConfigTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerDisableTimeoutsConfigTestCase.java
@@ -8,7 +8,7 @@ package org.mule.test.http.functional.listener;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.mule.runtime.core.api.InternalEvent;
+
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.test.http.functional.AbstractHttpTestCase;
@@ -16,6 +16,8 @@ import org.mule.test.http.functional.AbstractHttpTestCase;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mule.runtime.core.api.config.MuleProperties.MULE_DISABLE_RESPONSE_TIMEOUT;
+
+import org.mule.runtime.core.api.event.BaseEvent;
 
 public class HttpListenerDisableTimeoutsConfigTestCase extends AbstractHttpTestCase {
 
@@ -32,7 +34,7 @@ public class HttpListenerDisableTimeoutsConfigTestCase extends AbstractHttpTestC
 
   @Test
   public void httpListenerDefaultResponseTimeout() throws Exception {
-    final InternalEvent res = flowRunner("httpFlowWithDefaultResponseTimeout")
+    final BaseEvent res = flowRunner("httpFlowWithDefaultResponseTimeout")
         .withVariable("port", port.getNumber())
         .withPayload("hi")
         .run();
@@ -42,7 +44,7 @@ public class HttpListenerDisableTimeoutsConfigTestCase extends AbstractHttpTestC
 
   @Test
   public void httpListenerCustomResponseTimeout() throws Exception {
-    final InternalEvent res = flowRunner("httpFlowWithCustomResponseTimeout")
+    final BaseEvent res = flowRunner("httpFlowWithCustomResponseTimeout")
         .withVariable("port", port.getNumber())
         .withPayload("hi")
         .run();

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerMethodRoutingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerMethodRoutingTestCase.java
@@ -6,25 +6,26 @@
  */
 package org.mule.test.http.functional.listener;
 
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.OK;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 
 import org.mule.extension.http.api.HttpResponseAttributes;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.test.http.functional.AbstractHttpTestCase;
 import org.mule.test.runner.RunnerDelegateTo;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
 import io.qameta.allure.Feature;
 
 @RunnerDelegateTo(Parameterized.class)
@@ -69,11 +70,11 @@ public class HttpListenerMethodRoutingTestCase extends AbstractHttpTestCase {
   }
 
   private void sendRequestAndAssertMethod(String payload) throws Exception {
-    InternalEvent event = flowRunner("requestFlow").withPayload(payload).withVariable("method", method).run();
+    BaseEvent event = flowRunner("requestFlow").withPayload(payload).withVariable("method", method).run();
 
     HttpResponseAttributes attributes = (HttpResponseAttributes) event.getMessage().getAttributes().getValue();
     assertThat(attributes.getStatusCode(), is(OK.getStatusCode()));
-    assertThat(event.getMessageAsString(muleContext), is(expectedContent));
+    assertThat(event.getMessage().getPayload().getValue(), is(expectedContent));
   }
 
 }

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerNoBodyStatusTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerNoBodyStatusTestCase.java
@@ -15,7 +15,7 @@ import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NO_CONTENT;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.http.api.HttpConstants.HttpStatus;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -82,8 +82,8 @@ public class HttpListenerNoBodyStatusTestCase extends AbstractHttpTestCase {
   private static class StreamingProcessor implements Processor {
 
     @Override
-    public InternalEvent process(InternalEvent event) throws MuleException {
-      return InternalEvent.builder(event)
+    public BaseEvent process(BaseEvent event) throws MuleException {
+      return BaseEvent.builder(event)
           .message(Message.builder(event.getMessage()).value(new ByteArrayInputStream(new byte[] {})).build())
           .build();
     }

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerRequestStreamingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerRequestStreamingTestCase.java
@@ -12,16 +12,17 @@ import static org.junit.Assert.assertThat;
 import static org.mule.functional.api.component.FunctionalTestProcessor.getFromFlow;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 
+import org.mule.runtime.api.metadata.DataType;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.http.functional.AbstractHttpTestCase;
-
-import java.io.ByteArrayInputStream;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.InputStreamEntity;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
 
 import io.qameta.allure.Feature;
 
@@ -43,7 +44,8 @@ public class HttpListenerRequestStreamingTestCase extends AbstractHttpTestCase {
   public void listenerReceivedChunkedRequest() throws Exception {
     String url = format("http://localhost:%s/", listenPort.getNumber());
     getFromFlow(muleContext, "defaultFlow")
-        .setEventCallback((context, component, muleContext) -> flowReceivedMessage = context.getMessageAsString(muleContext));
+        .setEventCallback((context, component, muleContext) -> flowReceivedMessage = muleContext.getTransformationService()
+            .transform(context.getMessage(), DataType.STRING).getPayload().getValue().toString());
     testChunkedRequestContentAndResponse(url);
     // We check twice to verify that the chunked request is consumed completely. Otherwise second request would fail
     testChunkedRequestContentAndResponse(url);

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerTlsInsecureTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerTlsInsecureTestCase.java
@@ -13,7 +13,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import org.mule.functional.junit4.rules.ExpectedError;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.http.functional.AbstractHttpTestCase;
 
@@ -46,7 +46,7 @@ public class HttpListenerTlsInsecureTestCase extends AbstractHttpTestCase {
 
   @Test
   public void acceptsInvalidCertificateIfInsecure() throws Exception {
-    final InternalEvent res = flowRunner("testRequestToInsecure")
+    final BaseEvent res = flowRunner("testRequestToInsecure")
         .withPayload(TEST_PAYLOAD)
         .withVariable("port", port1.getNumber())
         .run();

--- a/src/test/java/org/mule/test/http/functional/requester/AbstractHttpRequestResponseStreamingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/AbstractHttpRequestResponseStreamingTestCase.java
@@ -9,7 +9,7 @@ package org.mule.test.http.functional.requester;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mule.runtime.api.message.Message.of;
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.processor.Processor;
 import org.mule.runtime.core.api.util.concurrent.Latch;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -73,7 +73,7 @@ public abstract class AbstractHttpRequestResponseStreamingTestCase extends Abstr
 
 
     @Override
-    public InternalEvent process(InternalEvent event) throws MuleException {
+    public BaseEvent process(BaseEvent event) throws MuleException {
       executed.set(true);
       return event;
     }
@@ -85,7 +85,7 @@ public abstract class AbstractHttpRequestResponseStreamingTestCase extends Abstr
     private static final int LISTENER_BUFFER = 8 * 1024;
 
     @Override
-    public InternalEvent process(InternalEvent event) throws MuleException {
+    public BaseEvent process(BaseEvent event) throws MuleException {
       InputStream inputStream = new InputStream() {
 
         private int sent = 0;
@@ -105,7 +105,7 @@ public abstract class AbstractHttpRequestResponseStreamingTestCase extends Abstr
           }
         }
       };
-      return InternalEvent.builder(event).message(of(inputStream)).build();
+      return BaseEvent.builder(event).message(of(inputStream)).build();
     }
 
   }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestAuthTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestAuthTestCase.java
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.util.FileUtils;
 
 import java.io.IOException;
@@ -64,7 +64,7 @@ public class HttpRequestAuthTestCase extends AbstractHttpRequestTestCase {
   }
 
   private void assertValidRequest(String flowName, String user, String password, boolean preemptive) throws Exception {
-    InternalEvent event = flowRunner(flowName).withPayload(TEST_MESSAGE).withVariable("user", user)
+    BaseEvent event = flowRunner(flowName).withPayload(TEST_MESSAGE).withVariable("user", user)
         .withVariable("password", password).withVariable("preemptive", preemptive).run();
 
     assertThat(event.getMessage().getPayload().getValue(), equalTo(DEFAULT_RESPONSE));

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestBodyTargetTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestBodyTargetTestCase.java
@@ -7,10 +7,12 @@
 package org.mule.test.http.functional.requester;
 
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
+
+import org.mule.runtime.core.api.event.BaseEvent;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import org.mule.runtime.core.api.InternalEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import org.junit.Test;
@@ -47,7 +49,7 @@ public class HttpRequestBodyTargetTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void responseBodyToPayloadTarget() throws Exception {
-    InternalEvent event = flowRunner("payloadTargetFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("payloadTargetFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
     assertThat(event.getMessage().getPayload().getValue(), equalTo(DEFAULT_RESPONSE));
   }
 }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestConnectionsPersistenceTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestConnectionsPersistenceTestCase.java
@@ -11,7 +11,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
-import org.mule.runtime.core.api.InternalEvent;
+
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.probe.JUnitProbe;
 import org.mule.tck.probe.PollingProber;
 
@@ -62,7 +63,7 @@ public class HttpRequestConnectionsPersistenceTestCase extends AbstractHttpReque
 
   @Test
   public void nonPersistentConnections() throws Exception {
-    InternalEvent response = flowRunner("nonPersistent").keepStreamsOpen().run();
+    BaseEvent response = flowRunner("nonPersistent").keepStreamsOpen().run();
     // verify that the connection is released shortly
     new PollingProber(SMALL_TIMEOUT_MILLIS, SMALL_POLL_DELAY_MILLIS).check(probe);
     // verify the stream is still available

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestDynamicConfigTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestDynamicConfigTestCase.java
@@ -21,7 +21,7 @@ import static org.mule.runtime.http.api.HttpHeaders.Names.HOST;
 import static org.mule.runtime.http.api.HttpHeaders.Names.TRANSFER_ENCODING;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import org.mule.functional.junit4.rules.ExpectedError;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -47,7 +47,7 @@ public class HttpRequestDynamicConfigTestCase extends AbstractHttpRequestTestCas
 
   @Test
   public void requestsGoThroughClient1() throws Exception {
-    InternalEvent result = flowRunner("client1")
+    BaseEvent result = flowRunner("client1")
         .withVariable("basePath", "api/v1")
         .withVariable("follow", true)
         .withVariable("send", "AUTO")
@@ -82,7 +82,7 @@ public class HttpRequestDynamicConfigTestCase extends AbstractHttpRequestTestCas
 
   @Test
   public void requestsGoThroughClient2() throws Exception {
-    InternalEvent result = flowRunner("client2")
+    BaseEvent result = flowRunner("client2")
         .withVariable("parse", false)
         .withVariable("stream", "AUTO")
         .withVariable("timeout", 20000)
@@ -113,7 +113,7 @@ public class HttpRequestDynamicConfigTestCase extends AbstractHttpRequestTestCas
 
   @Test
   public void requestWithDynamicConnectionParamUsesDifferentConfigs() throws Exception {
-    InternalEvent result = flowRunner("client2")
+    BaseEvent result = flowRunner("client2")
         .withVariable("parse", false)
         .withVariable("stream", "AUTO")
         .withVariable("timeout", 20000)

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestEncodingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestEncodingTestCase.java
@@ -10,7 +10,7 @@ import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.http.api.HttpHeaders;
 import org.mule.test.runner.RunnerDelegateTo;
 
@@ -63,7 +63,7 @@ public class HttpRequestEncodingTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void testEncoding() throws Exception {
-    InternalEvent result = flowRunner("encodingTest").withPayload(TEST_MESSAGE).run();
+    BaseEvent result = flowRunner("encodingTest").withPayload(TEST_MESSAGE).run();
     assertThat(getPayloadAsString(result.getMessage()), is(testMessage));
   }
 

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
@@ -32,7 +32,7 @@ import io.qameta.allure.Stories;
 
 import org.mule.functional.api.flow.FlowRunner;
 import org.mule.functional.junit4.rules.ExpectedError;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.util.concurrent.Latch;
 import org.mule.runtime.http.api.HttpConstants.HttpStatus;
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -124,14 +124,14 @@ public class HttpRequestErrorHandlingTestCase extends AbstractHttpRequestTestCas
   @Test
   public void timeout() throws Exception {
     timeout = true;
-    InternalEvent result = getFlowRunner("handled", httpPort.getNumber()).run();
+    BaseEvent result = getFlowRunner("handled", httpPort.getNumber()).run();
     done.release();
     assertThat(result.getMessage(), hasPayload(equalTo(getErrorMessage(": Timeout exceeded") + " timeout")));
   }
 
   @Test
   public void connectivity() throws Exception {
-    InternalEvent result = getFlowRunner("handled", unusedPort.getNumber()).run();
+    BaseEvent result = getFlowRunner("handled", unusedPort.getNumber()).run();
     assertThat(result.getMessage(), hasPayload(equalTo(getErrorMessage(": Connection refused", unusedPort) + " connectivity")));
   }
 
@@ -152,7 +152,7 @@ public class HttpRequestErrorHandlingTestCase extends AbstractHttpRequestTestCas
       throws Exception {
     serverStatus = status.getStatusCode();
     // Hit flow with error handler
-    InternalEvent result = getFlowRunner("handled", httpPort.getNumber()).run();
+    BaseEvent result = getFlowRunner("handled", httpPort.getNumber()).run();
     assertThat(result.getMessage().getPayload().getValue(), is(expectedResult));
     // Hit flow that will throw back the error
     if (!expectedError.endsWith("ANY")) {

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestExpectHeaderTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestExpectHeaderTestCase.java
@@ -12,7 +12,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import org.mule.extension.http.api.HttpResponseAttributes;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.test.http.functional.AbstractHttpExpectHeaderServerTestCase;
 import org.mule.test.http.functional.matcher.HttpMessageAttributesMatchers;
 
@@ -48,7 +48,7 @@ public class HttpRequestExpectHeaderTestCase extends AbstractHttpExpectHeaderSer
 
     // Set a payload that will fail when consumed. As the server rejects the request after processing
     // the header, the client should not send the body.
-    InternalEvent response = flowRunner(REQUEST_FLOW_NAME).withPayload(new InputStream() {
+    BaseEvent response = flowRunner(REQUEST_FLOW_NAME).withPayload(new InputStream() {
 
       @Override
       public int read() throws IOException {

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestFollowRedirectsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestFollowRedirectsTestCase.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.mule.runtime.api.exception.MuleException;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 
 import java.io.IOException;
 
@@ -138,7 +138,7 @@ public class HttpRequestFollowRedirectsTestCase extends AbstractHttpRequestTestC
   }
 
   private void doTest(String expectedPayload, String expectedPath, FlowRunner runner) throws MuleException, Exception {
-    InternalEvent result = runner.run();
+    BaseEvent result = runner.run();
     assertThat(getPayloadAsString(result.getMessage()), is(expectedPayload));
     assertThat(uri, is(expectedPath));
   }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestFunctionalTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestFunctionalTestCase.java
@@ -16,7 +16,7 @@ import static org.mule.functional.junit4.TestLegacyMessageUtils.getInboundProper
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.OK;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import org.mule.extension.http.api.HttpResponseAttributes;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.test.http.functional.matcher.HttpMessageAttributesMatchers;
@@ -50,7 +50,7 @@ public class HttpRequestFunctionalTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void responseBodyIsMappedToPayload() throws Exception {
-    InternalEvent event = flowRunner("requestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("requestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
     assertThat(event.getMessage().getPayload().getValue(), equalTo(DEFAULT_RESPONSE));
   }
 
@@ -59,21 +59,21 @@ public class HttpRequestFunctionalTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void blockingResponseBodyIsMappedToPayload() throws Exception {
-    InternalEvent event = flowRunner("blockingRequestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("blockingRequestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
     assertTrue(event.getMessage().getPayload().getValue() instanceof String);
     assertThat(event.getMessage().getPayload().getValue(), equalTo("value"));
   }
 
   @Test
   public void responseStatusCodeIsSetAsInboundProperty() throws Exception {
-    InternalEvent event = flowRunner("requestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("requestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
     assertThat((HttpResponseAttributes) event.getMessage().getAttributes().getValue(), HttpMessageAttributesMatchers
         .hasStatusCode(OK.getStatusCode()));
   }
 
   @Test
   public void responseHeadersAreMappedInAttributes() throws Exception {
-    InternalEvent event = flowRunner("requestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("requestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).run();
     HttpResponseAttributes responseAttributes = (HttpResponseAttributes) event.getMessage().getAttributes().getValue();
     assertThat(responseAttributes.getHeaders(), hasEntry(TEST_HEADER_NAME.toLowerCase(), TEST_HEADER_VALUE));
   }
@@ -86,7 +86,7 @@ public class HttpRequestFunctionalTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void previousInboundPropertiesAreCleared() throws Exception {
-    InternalEvent event =
+    BaseEvent event =
         flowRunner("requestFlow").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE)
             .withInboundProperty("TestInboundProperty", "TestValue").run();
     assertThat(getInboundProperty(event.getMessage(), "TestInboundProperty"), nullValue());

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestInboundPartsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestInboundPartsTestCase.java
@@ -16,7 +16,8 @@ import static org.mule.runtime.api.metadata.MediaType.MULTIPART_FORM_DATA;
 import static org.mule.runtime.api.metadata.MediaType.TEXT;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.MULTIPART;
-import org.mule.runtime.core.api.InternalEvent;
+
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.http.api.HttpHeaders;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public class HttpRequestInboundPartsTestCase extends AbstractHttpRequestTestCase
   @Test
   @Description("Verifies that parts are received, even considering an unknown type (HTML) and a custom header.")
   public void processInboundAttachments() throws Exception {
-    InternalEvent event = flowRunner("requestFlow").withPayload(TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("requestFlow").withPayload(TEST_MESSAGE).run();
     String contentType = event.getMessage().getPayload().getDataType().getMediaType().toRfcString();
 
     assertThat(contentType, startsWith(MULTIPART_FORM_DATA.withCharset(ISO_8859_1).toRfcString()));

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestMultipleValueHeadersTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestMultipleValueHeadersTestCase.java
@@ -16,7 +16,7 @@ import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.MULTI_MAP;
 import org.mule.extension.http.api.HttpResponseAttributes;
 import org.mule.runtime.api.util.CaseInsensitiveMapWrapper;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.junit4.rule.SystemProperty;
 
@@ -66,7 +66,7 @@ public class HttpRequestMultipleValueHeadersTestCase extends AbstractHttpRequest
   @Test
   @Description("Verifies that multiple valued headers received preserve order and format.")
   public void receivesMultipleValuedHeader() throws Exception {
-    InternalEvent event = runFlow("in");
+    BaseEvent event = runFlow("in");
 
     HttpResponseAttributes attributes = (HttpResponseAttributes) event.getMessage().getAttributes().getValue();
     List<String> headers = attributes.getHeaders().getAll("multipleheader");

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestProxyTlsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestProxyTlsTestCase.java
@@ -14,7 +14,7 @@ import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 
 import org.mule.extension.http.api.HttpRequestAttributes;
 import org.mule.extension.http.api.HttpResponseAttributes;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.test.http.functional.matcher.HttpMessageAttributesMatchers;
@@ -89,7 +89,7 @@ public class HttpRequestProxyTlsTestCase extends AbstractHttpTestCase {
 
     proxyServer.start();
 
-    InternalEvent event = flowRunner("clientFlow").withPayload(TEST_MESSAGE).withVariable("host", requestHost)
+    BaseEvent event = flowRunner("clientFlow").withPayload(TEST_MESSAGE).withVariable("host", requestHost)
         .withVariable("path", PATH).run();
 
     assertThat(requestPayload, equalTo(TEST_MESSAGE));

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestStreamingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestStreamingTestCase.java
@@ -17,7 +17,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.util.IOUtils;
 
 import java.io.ByteArrayInputStream;
@@ -150,7 +150,7 @@ public class HttpRequestStreamingTestCase extends AbstractHttpRequestTestCase {
     assertNoStreaming(runFlowWithPayload("streamingNever", TEST_MESSAGE));
   }
 
-  public InternalEvent runFlowWithPayload(String flow, Object payload) throws Exception {
+  public BaseEvent runFlowWithPayload(String flow, Object payload) throws Exception {
     return flowRunner(flow).withPayload(payload).withVariable(HEADERS, headersToSend).run();
   }
 
@@ -158,13 +158,13 @@ public class HttpRequestStreamingTestCase extends AbstractHttpRequestTestCase {
     headersToSend.put(name, value);
   }
 
-  private void assertNoStreaming(InternalEvent response) throws Exception {
+  private void assertNoStreaming(BaseEvent response) throws Exception {
     assertNull(transferEncodingHeader);
     assertThat(Integer.parseInt(contentLengthHeader), equalTo(TEST_MESSAGE.length()));
     assertThat(getPayloadAsString(response.getMessage()), equalTo(DEFAULT_RESPONSE));
   }
 
-  private void assertStreaming(InternalEvent response) throws Exception {
+  private void assertStreaming(BaseEvent response) throws Exception {
     assertThat(transferEncodingHeader, equalTo(CHUNKED));
     assertNull(contentLengthHeader);
     assertThat(response.getMessage().getPayload().getValue(), equalTo(DEFAULT_RESPONSE));

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestTlsConnectionCloseTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestTlsConnectionCloseTestCase.java
@@ -14,7 +14,7 @@ import static org.mule.runtime.http.api.HttpHeaders.Names.CONNECTION;
 import static org.mule.runtime.http.api.HttpHeaders.Values.CLOSE;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class HttpRequestTlsConnectionCloseTestCase extends AbstractHttpRequestTe
 
   @Test
   public void handlesRequest() throws Exception {
-    InternalEvent response = flowRunner("testFlowHttps").withPayload(AbstractMuleTestCase.TEST_PAYLOAD).run();
+    BaseEvent response = flowRunner("testFlowHttps").withPayload(AbstractMuleTestCase.TEST_PAYLOAD).run();
     assertThat(response.getMessage(), hasPayload(equalTo((DEFAULT_RESPONSE))));
   }
 }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestTlsInsecureTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestTlsInsecureTestCase.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 import org.mule.functional.junit4.rules.ExpectedError;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.tck.junit4.rule.DynamicPort;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.test.http.functional.AbstractHttpTestCase;
@@ -61,7 +61,7 @@ public class HttpRequestTlsInsecureTestCase extends AbstractHttpTestCase {
 
   @Test
   public void insecureRequest() throws Exception {
-    final InternalEvent res = flowRunner("testInsecureRequest").withPayload(TEST_PAYLOAD).run();
+    final BaseEvent res = flowRunner("testInsecureRequest").withPayload(TEST_PAYLOAD).run();
     assertThat(res.getMessage().getPayload().getValue(), is(TEST_PAYLOAD));
   }
 

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestUrlEncodedTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestUrlEncodedTestCase.java
@@ -14,7 +14,8 @@ import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
 import static org.mule.runtime.http.api.HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED;
 import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.URL_ENCODED;
-import org.mule.runtime.core.api.InternalEvent;
+
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.http.api.HttpHeaders;
 
 import java.io.IOException;
@@ -48,7 +49,7 @@ public class HttpRequestUrlEncodedTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void receivesUrlEncodedBody() throws Exception {
-    InternalEvent event = flowRunner("formParamInbound").withPayload(TEST_MESSAGE).run();
+    BaseEvent event = flowRunner("formParamInbound").withPayload(TEST_MESSAGE).run();
 
     assertThat(event.getMessage(), hasPayload(equalTo("testValue1testValue2")));
   }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestValidateCertificateTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestValidateCertificateTestCase.java
@@ -13,7 +13,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.security.GeneralSecurityException;
@@ -43,7 +43,7 @@ public class HttpRequestValidateCertificateTestCase extends AbstractHttpRequestT
 
   @Test
   public void acceptsValidCertificate() throws Exception {
-    InternalEvent result = flowRunner("validCertFlow").withPayload(TEST_MESSAGE).run();
+    BaseEvent result = flowRunner("validCertFlow").withPayload(TEST_MESSAGE).run();
     assertThat(result.getMessage().getPayload().getValue(), equalTo(DEFAULT_RESPONSE));
   }
 }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRestrictedCiphersAndProtocolsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRestrictedCiphersAndProtocolsTestCase.java
@@ -20,7 +20,7 @@ import org.mule.extension.http.api.error.HttpRequestFailedException;
 import org.mule.functional.junit4.rules.ExpectedError;
 import org.mule.runtime.api.tls.TlsContextFactory;
 import org.mule.runtime.api.tls.TlsContextFactoryBuilder;
-import org.mule.runtime.core.api.InternalEvent;
+import org.mule.runtime.core.api.event.BaseEvent;
 import org.mule.runtime.core.api.util.IOUtils;
 import org.mule.runtime.http.api.HttpService;
 import org.mule.runtime.http.api.client.HttpClient;
@@ -83,7 +83,7 @@ public class HttpRestrictedCiphersAndProtocolsTestCase extends AbstractHttpTestC
 
   @Test
   public void worksWithProtocolAndCipherSuiteMatch() throws Exception {
-    InternalEvent response = flowRunner("12Client12Server").withPayload(TEST_PAYLOAD).run();
+    BaseEvent response = flowRunner("12Client12Server").withPayload(TEST_PAYLOAD).run();
     assertThat(response.getMessage().getPayload().getValue(), is(TEST_PAYLOAD));
   }
 


### PR DESCRIPTION
* Change security filter return type to 
* Remove some deprecated usages
* Event interface split