### PR TITLE
MULE-9669: added port to the error

### DIFF
--- a/src/main/java/org/mule/extension/http/internal/listener/HttpListenerProvider.java
+++ b/src/main/java/org/mule/extension/http/internal/listener/HttpListenerProvider.java
@@ -191,7 +191,7 @@ public class HttpListenerProvider implements CachedConnectionProvider<HttpServer
     try {
       server.start();
     } catch (IOException e) {
-      throw new DefaultMuleException(new ConnectionException("Could not start HTTP server", e));
+      throw new DefaultMuleException(new ConnectionException("Could not start HTTP server for " + configName + " on port " + connectionParams.port, e));
     }
   }
 


### PR DESCRIPTION
Added the configuration name and the port to the error while starting the server so it can be easily identified