### PR TITLE
MULE-14950: Fix OperationPolicyPointcutParametersParameters can not b…

### DIFF
--- a/src/main/java/org/mule/extension/http/api/policy/HttpRequestPolicyPointcutParametersFactory.java
+++ b/src/main/java/org/mule/extension/http/api/policy/HttpRequestPolicyPointcutParametersFactory.java
@@ -13,7 +13,6 @@ import static org.mule.runtime.api.component.ComponentIdentifier.builder;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.policy.api.OperationPolicyPointcutParametersFactory;
-import org.mule.runtime.policy.api.OperationPolicyPointcutParametersParameters;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 
 import java.util.Map;
@@ -49,15 +48,17 @@ public class HttpRequestPolicyPointcutParametersFactory implements OperationPoli
   }
 
   @Override
-  public PolicyPointcutParameters createPolicyPointcutParameters(OperationPolicyPointcutParametersParameters pointcutParametersParameters) {
-    requireNonNull(pointcutParametersParameters.getOperation(),
+  public PolicyPointcutParameters createPolicyPointcutParameters(Component requester,
+                                                                 Map<String, Object> operationParameters,
+                                                                 PolicyPointcutParameters sourceParameters) {
+    requireNonNull(requester,
                    "Cannot create a policy pointcut parameter instance without a valid component");
 
-    String pathParameter = (String) pointcutParametersParameters.getOperationParameters().get(PATH_PARAMETER_NAME);
-    String methodParameter = (String) pointcutParametersParameters.getOperationParameters().get(METHOD_PARAMETER_NAME);
+    String pathParameter = (String) operationParameters.get(PATH_PARAMETER_NAME);
+    String methodParameter = (String) operationParameters.get(METHOD_PARAMETER_NAME);
 
-    return new HttpRequestPolicyPointcutParameters(pointcutParametersParameters.getOperation(),
-                                                   pointcutParametersParameters.getSourceParameters(),
+    return new HttpRequestPolicyPointcutParameters(requester,
+                                                   sourceParameters,
                                                    pathParameter,
                                                    methodParameter);
   }

--- a/src/test/java/org/mule/test/http/policy/HttpRequestPolicyPointcutParametersFactoryTestCase.java
+++ b/src/test/java/org/mule/test/http/policy/HttpRequestPolicyPointcutParametersFactoryTestCase.java
@@ -21,14 +21,12 @@ import org.mule.extension.http.api.policy.HttpRequestPolicyPointcutParameters;
 import org.mule.extension.http.api.policy.HttpRequestPolicyPointcutParametersFactory;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.component.ComponentIdentifier;
-import org.mule.runtime.policy.api.OperationPolicyPointcutParametersParameters;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-import java.util.Optional;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
@@ -87,11 +85,9 @@ public class HttpRequestPolicyPointcutParametersFactoryTestCase extends Abstract
         ImmutableMap.<String, Object>builder().put(HttpRequestPolicyPointcutParametersFactory.METHOD_PARAMETER_NAME, TEST_METHOD)
             .put(PATH_PARAMETER_NAME, TEST_REQUEST_PATH).build();
     PolicyPointcutParameters sourceParameters = mock(PolicyPointcutParameters.class);
-    OperationPolicyPointcutParametersParameters parameters =
-        new OperationPolicyPointcutParametersParameters(component, parametersMap, sourceParameters);
 
     HttpRequestPolicyPointcutParameters policyPointcutParameters =
-        (HttpRequestPolicyPointcutParameters) factory.createPolicyPointcutParameters(parameters);
+        (HttpRequestPolicyPointcutParameters) factory.createPolicyPointcutParameters(component, parametersMap, sourceParameters);
 
     assertThat(policyPointcutParameters.getComponent(), is(component));
     assertThat(policyPointcutParameters.getSourceParameters(), is(of(sourceParameters)));


### PR DESCRIPTION
…e found when deploying in runtimes lower than 4.1.2