### PR TITLE
MULE-15685: Fix HTTP connector tests in Windows

### DIFF
--- a/src/test/java/org/mule/test/http/functional/requester/ocsp/AbstractHttpOcspRevocationTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/ocsp/AbstractHttpOcspRevocationTestCase.java
@@ -8,6 +8,7 @@
 package org.mule.test.http.functional.requester.ocsp;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.junit.Assume.assumeFalse;
 
 import org.mule.tck.junit4.rule.DynamicPort;
@@ -83,6 +84,7 @@ public abstract class AbstractHttpOcspRevocationTestCase extends AbstractHttpTls
 
   @Before
   public void setUp() throws Exception {
+    assumeFalse(IS_OS_WINDOWS);
     process = Runtime.getRuntime().exec(format(RUN_OCSP_SERVER_COMMAND, ocspList, ocspPort, ocspResponder, ocspResponder));
     assumeFalse("Since openssl ocsp command has a flaky behavior the test will be ignored if an error occurs in server initialisation.",
                 getOcspServerCommandOutput(process.getErrorStream()).contains("Error"));


### PR DESCRIPTION
Correction of tests with OCSP REVOCATION and NO REVOCATION.

The main cause was found because Openssl is not installed by default in a Windows environment, it was tried to install Openssl for Windows but it did not work correctly; however, the setup() of these tests was omitted and the Openssl that was in the same Windows network was configured in another Unix machine and it was verified that the tests do not have any problem, the tests work well.

These tests will not run in the Windows environment.