### PR TITLE
MULE-16140: Source On Error callback is not called when an error occurs

### DIFF
--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerErrorHandlingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerErrorHandlingTestCase.java
@@ -10,12 +10,14 @@ import static org.apache.http.client.fluent.Request.Get;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERROR_HANDLING;
+
 import org.mule.runtime.core.api.util.IOUtils;
 
-import io.qameta.allure.Story;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Response;
 import org.junit.Test;
+
+import io.qameta.allure.Story;
 
 @Story(ERROR_HANDLING)
 public class HttpListenerErrorHandlingTestCase extends AbstractHttpListenerErrorHandlingTestCase {
@@ -53,22 +55,6 @@ public class HttpListenerErrorHandlingTestCase extends AbstractHttpListenerError
     assertThat(IOUtils.toString(httpResponse.getEntity().getContent()),
                is("An error occurred: Functional Test Service Exception"));
     assertThat(httpResponse.getFirstHeader("headername").getValue(), is("headerValue"));
-  }
-
-  @Test
-  public void exceptionInPropagateErrorHandlerSkipsErrorResponse() throws Exception {
-    final Response response = Get(getUrl("exceptionInPropagateErrorHandler")).execute();
-    final HttpResponse httpResponse = response.returnResponse();
-
-    assertThat(IOUtils.toString(httpResponse.getEntity().getContent()), is("Functional Test Service Exception"));
-  }
-
-  @Test
-  public void exceptionInContinueErrorHandlerSkipsErrorResponse() throws Exception {
-    final Response response = Get(getUrl("exceptionInContinueErrorHandler")).execute();
-    final HttpResponse httpResponse = response.returnResponse();
-
-    assertThat(IOUtils.toString(httpResponse.getEntity().getContent()), is("Functional Test Service Exception"));
   }
 
 }

--- a/src/test/resources/http-listener-error-handling-config.xml
+++ b/src/test/resources/http-listener-error-handling-config.xml
@@ -83,34 +83,4 @@
             </on-error-continue>
         </error-handler>
     </flow>
-
-    <flow name="exceptionInPropagateErrorHandler">
-        <http:listener config-ref="listenerConfig" path="/exceptionInPropagateErrorHandler">
-            <http:error-response>
-                <http:body>errorResponse</http:body>
-            </http:error-response>
-        </http:listener>
-        <test:processor throwException="true"/>
-        <error-handler>
-            <on-error-propagate>
-                <set-payload value="errorHandler"/>
-                <test:processor throwException="true"/>
-            </on-error-propagate>
-        </error-handler>
-    </flow>
-
-    <flow name="exceptionInContinueErrorHandler">
-        <http:listener config-ref="listenerConfig" path="/exceptionInContinueErrorHandler">
-            <http:error-response>
-                <http:body>errorResponse</http:body>
-            </http:error-response>
-        </http:listener>
-        <test:processor throwException="true"/>
-        <error-handler>
-            <on-error-continue>
-                <set-payload value="errorHandler"/>
-                <test:processor throwException="true"/>
-            </on-error-continue>
-        </error-handler>
-    </flow>
 </mule>


### PR DESCRIPTION
on the OnError Flow Handlers

* Removing tests that make no sense. When interacting with the source for handling an error, it should not matter whether the error was produced inside an error handler or not, only if it happened in the flow.