### PR TITLE
MULE-16035: HTTP Connector does not implement equals/hash on POJOs

### DIFF
--- a/src/main/java/org/mule/extension/http/api/request/builder/RequestHeader.java
+++ b/src/main/java/org/mule/extension/http/api/request/builder/RequestHeader.java
@@ -9,6 +9,8 @@ package org.mule.extension.http.api.request.builder;
 import org.mule.runtime.extension.api.annotation.Alias;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 
+import java.util.Objects;
+
 /**
  * Represents an HTTP Header
  *
@@ -29,6 +31,24 @@ public class RequestHeader {
 
   public String getValue() {
     return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RequestHeader that = (RequestHeader) o;
+    return Objects.equals(key, that.key) &&
+        Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value);
   }
 
 }


### PR DESCRIPTION
Missing equals/hashCode was still generating OOM Metaspace as CGLIB classes were created for the CachedConnectionProvider when using expressions on http:default-header