### PR TITLE
MULE-16669: Mule throws error Illegal group reference Exception when …

### DIFF
--- a/src/main/java/org/mule/extension/http/api/request/builder/HttpRequesterRequestBuilder.java
+++ b/src/main/java/org/mule/extension/http/api/request/builder/HttpRequesterRequestBuilder.java
@@ -116,7 +116,7 @@ public class HttpRequesterRequestBuilder extends HttpMessageBuilder {
         throw new NullPointerException(format("Expression {%s} evaluated to null.", uriParamName));
       }
 
-      path = path.replaceAll("\\{" + uriParamName + "}", quoteReplacement(uriParamValue));
+      path = path.replaceAll("\\{" + uriParamName + "\\}", quoteReplacement(uriParamValue));
     }
     return path;
   }

--- a/src/main/java/org/mule/extension/http/api/request/builder/HttpRequesterRequestBuilder.java
+++ b/src/main/java/org/mule/extension/http/api/request/builder/HttpRequesterRequestBuilder.java
@@ -9,6 +9,7 @@ package org.mule.extension.http.api.request.builder;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.regex.Matcher.quoteReplacement;
 import static org.mule.runtime.api.util.MultiMap.emptyMultiMap;
 import static org.mule.runtime.extension.api.runtime.parameter.OutboundCorrelationStrategy.AUTO;
 import static org.mule.runtime.http.api.server.HttpServerProperties.PRESERVE_HEADER_CASE;
@@ -115,7 +116,7 @@ public class HttpRequesterRequestBuilder extends HttpMessageBuilder {
         throw new NullPointerException(format("Expression {%s} evaluated to null.", uriParamName));
       }
 
-      path = path.replaceAll("\\{" + uriParamName + "\\}", uriParamValue);
+      path = path.replaceAll(format("\\{%s}", uriParamName), quoteReplacement(uriParamValue));
     }
     return path;
   }

--- a/src/main/java/org/mule/extension/http/api/request/builder/HttpRequesterRequestBuilder.java
+++ b/src/main/java/org/mule/extension/http/api/request/builder/HttpRequesterRequestBuilder.java
@@ -116,7 +116,7 @@ public class HttpRequesterRequestBuilder extends HttpMessageBuilder {
         throw new NullPointerException(format("Expression {%s} evaluated to null.", uriParamName));
       }
 
-      path = path.replaceAll(format("\\{%s}", uriParamName), quoteReplacement(uriParamValue));
+      path = path.replaceAll("\\{" + uriParamName + "}", quoteReplacement(uriParamValue));
     }
     return path;
   }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
@@ -10,7 +10,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
-import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +30,7 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void sendsUriParamsFromList() throws Exception {
-    flowRunner("uriParamList").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).withVariable("paramName", "testParam2")
+    flowRunner("uriParamList").withPayload(TEST_MESSAGE).withVariable("paramName", "testParam2")
         .withVariable("paramValue", "testValue2").run();
     assertThat(uri, equalTo("/testPath/testValue1/testValue2"));
   }
@@ -41,7 +40,7 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
     Map<String, String> params = new HashMap<>();
     params.put("testParam1", "testValue1");
     params.put("testParam2", "testValue2");
-    flowRunner("uriParamMap").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).withVariable("params", params).run();
+    flowRunner("uriParamMap").withPayload(TEST_MESSAGE).withVariable("params", params).run();
 
     assertThat(uri, equalTo("/testPath/testValue1/testValue2"));
   }
@@ -51,7 +50,7 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
     Map<String, String> params = new HashMap<>();
     params.put("testParam1", "testValueNew");
     params.put("testParam2", "testValue2");
-    flowRunner("uriParamOverride").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE).withVariable("params", params).run();
+    flowRunner("uriParamOverride").withPayload(TEST_MESSAGE).withVariable("params", params).run();
 
     assertThat(uri, equalTo("/testPath/testValueNew/testValue2"));
   }
@@ -65,7 +64,7 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void uriParamsContainsReservedUriCharacter() throws Exception {
-    flowRunner("reservedUriCharacter").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE)
+    flowRunner("reservedUriCharacter").withPayload(TEST_MESSAGE)
         .withVariable("paramName", "testParam").withVariable("paramValue", "$a").run();
 
     assertThat(uri, equalTo("/testPath/$a"));
@@ -73,7 +72,7 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void uriParamsWithRegEx() throws Exception {
-    flowRunner("regEx").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE)
+    flowRunner("regEx").withPayload(TEST_MESSAGE)
         .withVariable("paramName", "[1-9]").withVariable("paramValue", "abc").run();
 
     assertThat(uri, equalTo("/testPath/abc"));

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
@@ -63,4 +63,19 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
     flowRunner("uriParamNull").run();
   }
 
+  @Test
+  public void uriParamsContainsReservedUriCharacter() throws Exception {
+    flowRunner("reservedUriCharacter").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE)
+        .withVariable("paramName", "testParam").withVariable("paramValue", "$a").run();
+
+    assertThat(uri, equalTo("/testPath/$a"));
+  }
+
+  @Test
+  public void uriParamsWithRegEx() throws Exception {
+    flowRunner("regEx").withPayload(AbstractMuleContextTestCase.TEST_MESSAGE)
+        .withVariable("paramName", "[1-9]").withVariable("paramValue", "abc").run();
+
+    assertThat(uri, equalTo("/testPath/abc"));
+  }
 }

--- a/src/test/resources/http-request-uri-params-config.xml
+++ b/src/test/resources/http-request-uri-params-config.xml
@@ -42,4 +42,20 @@
         </http:request>
     </flow>
 
+    <flow name="reservedUriCharacter">
+        <http:request config-ref="config" path="testPath/{testParam}">
+            <http:uri-params>
+                #[(vars.paramName): vars.paramValue]
+            </http:uri-params>
+        </http:request>
+    </flow>
+
+    <flow name="regEx">
+        <http:request config-ref="config" path="testPath/{8}">
+            <http:uri-params>
+                #[(vars.paramName): vars.paramValue]
+            </http:uri-params>
+        </http:request>
+    </flow>
+
 </mule>


### PR DESCRIPTION
…trying to pass $ into URI Parameter in HTTP request