### PR TITLE
MULE-17848: Add builder methods for http attribute classes (#377)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,14 @@
         <!-- This dependencies must be explicitly defined as long as HTTP supports runtimes prior to 4.1.2 -->
         <muleHttpPolicyApiVersion>1.1.2</muleHttpPolicyApiVersion>
         <mulePolicyApiVersion>1.1.2</mulePolicyApiVersion>
+
+        <!-- Remove when a new parent version with MTF is available -->
+        <munit.input.directory>src/test/munit</munit.input.directory>
+        <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
+        <munit.extensions.maven.plugin.version>1.0.0-BETA4</munit.extensions.maven.plugin.version>
+        <munit.version>2.2.3-SNAPSHOT</munit.version>
+        <mtf-tools.version>1.0.0-BETA4</mtf-tools.version>
+        <mavenResources.version>3.0.2</mavenResources.version>
     </properties>
 
     <build>
@@ -54,6 +62,76 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${mavenResources.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-munit-resources</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${munit.output.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${munit.input.directory}</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.mulesoft.munit</groupId>
+                <artifactId>munit-extensions-maven-plugin</artifactId>
+                <version>${munit.extensions.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <argLines>
+                        <argLine>
+                            -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco.exec
+                        </argLine>
+                    </argLines>
+                    <runtimeConfiguration>
+                        <discoverRuntimes>
+                            <product>ALL</product>
+                            <includeSnapshots>true</includeSnapshots>
+                        </discoverRuntimes>
+                    </runtimeConfiguration>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>munit-runner</artifactId>
+                        <version>${munit.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>munit-tools</artifactId>
+                        <version>${munit.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>mtf-tools</artifactId>
+                        <version>${mtf-tools.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/mule/extension/http/api/HttpRequestAttributes.java
+++ b/src/main/java/org/mule/extension/http/api/HttpRequestAttributes.java
@@ -7,6 +7,7 @@
 package org.mule.extension.http.api;
 
 import static java.lang.System.lineSeparator;
+
 import org.mule.extension.http.internal.certificate.CertificateProvider;
 import org.mule.extension.http.internal.certificate.CertificateProviderFactory;
 import org.mule.runtime.api.util.MultiMap;
@@ -25,6 +26,10 @@ import java.util.function.Supplier;
 public class HttpRequestAttributes extends BaseHttpRequestAttributes {
 
   private static final long serialVersionUID = 7227330842640270811L;
+
+  public static HttpRequestAttributesBuilder builder() {
+    return new HttpRequestAttributesBuilder();
+  }
 
   /**
    * Full path where the request was received. Former 'http.listener.path'.
@@ -215,6 +220,7 @@ public class HttpRequestAttributes extends BaseHttpRequestAttributes {
     return this.clientCertificate;
   }
 
+  @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
     builder.append(this.getClass().getName()).append(lineSeparator()).append("{").append(lineSeparator())

--- a/src/main/java/org/mule/extension/http/api/HttpRequestAttributesBuilder.java
+++ b/src/main/java/org/mule/extension/http/api/HttpRequestAttributesBuilder.java
@@ -10,6 +10,7 @@ import static java.lang.String.valueOf;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static org.mule.runtime.api.util.MultiMap.emptyMultiMap;
+
 import org.mule.runtime.api.util.MultiMap;
 
 import java.security.cert.Certificate;

--- a/src/main/java/org/mule/extension/http/api/HttpResponseAttributes.java
+++ b/src/main/java/org/mule/extension/http/api/HttpResponseAttributes.java
@@ -7,6 +7,8 @@
 package org.mule.extension.http.api;
 
 import static java.lang.System.lineSeparator;
+
+import org.mule.extension.http.internal.request.builder.HttpResponseAttributesBuilder;
 import org.mule.runtime.api.util.MultiMap;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 
@@ -18,6 +20,10 @@ import org.mule.runtime.extension.api.annotation.param.Parameter;
 public class HttpResponseAttributes extends HttpAttributes {
 
   private static final long serialVersionUID = -3131769059554988414L;
+
+  public static HttpResponseAttributesBuilder builder() {
+    return new HttpResponseAttributesBuilder();
+  }
 
   /**
    * HTTP status code of the response. Former 'http.status'.
@@ -45,6 +51,7 @@ public class HttpResponseAttributes extends HttpAttributes {
     return reasonPhrase;
   }
 
+  @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
 

--- a/src/main/java/org/mule/extension/http/internal/request/builder/HttpResponseAttributesBuilder.java
+++ b/src/main/java/org/mule/extension/http/internal/request/builder/HttpResponseAttributesBuilder.java
@@ -18,8 +18,6 @@ import org.mule.runtime.http.api.domain.message.response.HttpResponse;
  */
 public class HttpResponseAttributesBuilder {
 
-  HttpResponse response;
-
   private MultiMap<String, String> headers = emptyMultiMap();
   private int statusCode;
   private String reasonPhrase;
@@ -29,7 +27,6 @@ public class HttpResponseAttributesBuilder {
     this.statusCode = response.getStatusCode();
     this.reasonPhrase = response.getReasonPhrase();
 
-    this.response = response;
     return this;
   }
 

--- a/src/main/java/org/mule/extension/http/internal/request/builder/HttpResponseAttributesBuilder.java
+++ b/src/main/java/org/mule/extension/http/internal/request/builder/HttpResponseAttributesBuilder.java
@@ -6,7 +6,11 @@
  */
 package org.mule.extension.http.internal.request.builder;
 
+import static java.util.Objects.requireNonNull;
+import static org.mule.runtime.api.util.MultiMap.emptyMultiMap;
+
 import org.mule.extension.http.api.HttpResponseAttributes;
+import org.mule.runtime.api.util.MultiMap;
 import org.mule.runtime.http.api.domain.message.response.HttpResponse;
 
 /**
@@ -16,15 +20,36 @@ public class HttpResponseAttributesBuilder {
 
   HttpResponse response;
 
+  private MultiMap<String, String> headers = emptyMultiMap();
+  private int statusCode;
+  private String reasonPhrase;
+
   public HttpResponseAttributesBuilder setResponse(HttpResponse response) {
+    this.headers = response.getHeaders();
+    this.statusCode = response.getStatusCode();
+    this.reasonPhrase = response.getReasonPhrase();
+
     this.response = response;
     return this;
   }
 
-  public HttpResponseAttributes build() {
-    int statusCode = response.getStatusCode();
-    String reasonPhrase = response.getReasonPhrase();
+  public HttpResponseAttributesBuilder headers(MultiMap<String, String> headers) {
+    requireNonNull(headers, "HTTP headers cannot be null.");
+    this.headers = headers;
+    return this;
+  }
 
-    return new HttpResponseAttributes(statusCode, reasonPhrase, response.getHeaders());
+  public HttpResponseAttributesBuilder statusCode(int statusCode) {
+    this.statusCode = statusCode;
+    return this;
+  }
+
+  public HttpResponseAttributesBuilder reasonPhrase(String reasonPhrase) {
+    this.reasonPhrase = reasonPhrase;
+    return this;
+  }
+
+  public HttpResponseAttributes build() {
+    return new HttpResponseAttributes(statusCode, reasonPhrase, headers);
   }
 }

--- a/src/test/munit/attributes/attributes-created-dw-test-case.xml
+++ b/src/test/munit/attributes/attributes-created-dw-test-case.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns:mule="http://www.mulesoft.org/schema/mule/core"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                          http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+                          http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+                          http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd">
+
+    <munit:config name="attributes-created-dw" minMuleVersion="4.3.0"/>
+
+    <munit:test name="mockAuthorizationRequest" description="Validates that the authorization request can be mocked">
+        <munit:execution>
+            <set-payload value="#[{method : 'POST', headers: {Authorization: 'Basic YWRtaW46YWRtaW4='}, listenerPath: '/', relativePath: '/', version: 'HTTP/1.1', scheme: 'http', requestPath: '/', requestUri: 'localhost:8080/', localAddress: '127.0.0.1', remoteAddress: '127.0.0.1' } as Object { class : 'org.mule.extension.http.api.HttpRequestAttributes'}]"/>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.headers['Authorization']]" is="#[MunitTools::equalTo('Basic YWRtaW46YWRtaW4=')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="mockAuthorizationResponse" description="Validates that the authorization response can be mocked" >
+        <munit:execution>
+            <set-payload value="#[{statusCode : 200, headers: {Authorization: 'Basic YWRtaW46YWRtaW4='} } as Object { class : 'org.mule.extension.http.api.HttpResponseAttributes'}]"/>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[payload.headers['Authorization']]" is="#[MunitTools::equalTo('Basic YWRtaW46YWRtaW4=')]"/>
+        </munit:validation>
+    </munit:test>
+
+</mule>


### PR DESCRIPTION
* Also, add support for MTF tests

Cherry pick for 1.5.x, had to cherrypick some changes in `HttpResponseAttributesBuilder ` also.