### PR TITLE
MULE-17927: Remove deprecated expression-transformer in http-connector test (min version 4.3.0)

### DIFF
--- a/src/test/resources/http-listener-expect-header-streaming-auto-stream-config.xml
+++ b/src/test/resources/http-listener-expect-header-streaming-auto-stream-config.xml
@@ -12,7 +12,7 @@
 
     <flow name="defaultFlow">
         <http:listener config-ref="listenerConfig"  path="/" responseStreamingMode="AUTO"/>
-        <expression-transformer expression="mel:new StringBufferInputStream(message.payloadAs(String))"/>
+        <set-payload value="#[mel:new StringBufferInputStream(message.payloadAs(String))]"/>
     </flow>
 
 </mule>


### PR DESCRIPTION
test