### PR TITLE
Revert "MULE-17985: Support policy application depending on request headers"

### DIFF
--- a/src/main/java/org/mule/extension/http/api/policy/HttpListenerPolicyPointcutParameters.java
+++ b/src/main/java/org/mule/extension/http/api/policy/HttpListenerPolicyPointcutParameters.java
@@ -7,7 +7,6 @@
 package org.mule.extension.http.api.policy;
 
 import org.mule.runtime.api.component.Component;
-import org.mule.runtime.api.util.MultiMap;
 import org.mule.runtime.http.policy.api.HttpPolicyPointcutParameters;
 import org.mule.runtime.policy.api.PolicyPointcutParameters;
 
@@ -18,8 +17,6 @@ import org.mule.runtime.policy.api.PolicyPointcutParameters;
  */
 public class HttpListenerPolicyPointcutParameters extends HttpPolicyPointcutParameters {
 
-  private final MultiMap<String, String> headers;
-
   /**
    * Creates a new {@link PolicyPointcutParameters}
    *
@@ -28,24 +25,7 @@ public class HttpListenerPolicyPointcutParameters extends HttpPolicyPointcutPara
    * @param method the HTTP method of the incoming request
    */
   public HttpListenerPolicyPointcutParameters(Component component, String path, String method) {
-    this(component, path, method, MultiMap.emptyMultiMap());
-  }
-
-  /**
-   * Creates a new {@link PolicyPointcutParameters}
-   *
-   * @param component the component where the policy is being applied.
-   * @param path the target path of the incoming request
-   * @param method the HTTP method of the incoming request
-   * @param headers the HTTP headers of the incoming request
-   */
-  public HttpListenerPolicyPointcutParameters(Component component, String path, String method, MultiMap<String, String> headers) {
     super(component, path, method);
-    this.headers = headers;
-  }
-
-  public MultiMap<String, String> getHeaders() {
-    return headers;
   }
 
 }

--- a/src/main/java/org/mule/extension/http/api/policy/HttpListenerPolicyPointcutParametersFactory.java
+++ b/src/main/java/org/mule/extension/http/api/policy/HttpListenerPolicyPointcutParametersFactory.java
@@ -44,7 +44,7 @@ public class HttpListenerPolicyPointcutParametersFactory implements SourcePolicy
 
     HttpRequestAttributes httpRequestAttributes = (HttpRequestAttributes) attributes.getValue();
     return new HttpListenerPolicyPointcutParameters(component, httpRequestAttributes.getRequestPath(),
-                                                    httpRequestAttributes.getMethod(), httpRequestAttributes.getHeaders());
+                                                    httpRequestAttributes.getMethod());
   }
 
 }

--- a/src/test/java/org/mule/test/http/policy/HttpListenerPolicyPointcutParametersFactoryTestCase.java
+++ b/src/test/java/org/mule/test/http/policy/HttpListenerPolicyPointcutParametersFactoryTestCase.java
@@ -21,7 +21,6 @@ import org.mule.extension.http.api.policy.HttpListenerPolicyPointcutParametersFa
 import org.mule.runtime.api.component.ComponentIdentifier;
 import org.mule.runtime.api.component.Component;
 import org.mule.runtime.api.metadata.TypedValue;
-import org.mule.runtime.api.util.MultiMap;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import io.qameta.allure.Story;
@@ -36,17 +35,11 @@ public class HttpListenerPolicyPointcutParametersFactoryTestCase extends Abstrac
       builder().namespace("http").name("listener").build();
   private static final String TEST_REQUEST_PATH = "test-request-path";
   private static final String TEST_METHOD = "PUT";
-  private static final MultiMap<String, String> TEST_HEADERS;
 
   private final HttpListenerPolicyPointcutParametersFactory factory = new HttpListenerPolicyPointcutParametersFactory();
   private final Component component = mock(Component.class);
   private final HttpRequestAttributes httpAttributes = mock(HttpRequestAttributes.class);
   private final TypedValue attributes = new TypedValue(mock(Object.class), OBJECT);
-
-  static {
-    TEST_HEADERS = new MultiMap<>();
-    TEST_HEADERS.put("headerKey", "headerValue");
-  }
 
   @Test
   public void supportsHttpListener() {
@@ -76,7 +69,6 @@ public class HttpListenerPolicyPointcutParametersFactoryTestCase extends Abstrac
   public void policyPointcutParameters() {
     when(httpAttributes.getRequestPath()).thenReturn(TEST_REQUEST_PATH);
     when(httpAttributes.getMethod()).thenReturn(TEST_METHOD);
-    when(httpAttributes.getHeaders()).thenReturn(TEST_HEADERS);
 
     HttpListenerPolicyPointcutParameters policyPointcutParameters =
         (HttpListenerPolicyPointcutParameters) factory.createPolicyPointcutParameters(component,
@@ -85,7 +77,6 @@ public class HttpListenerPolicyPointcutParametersFactoryTestCase extends Abstrac
     assertThat(policyPointcutParameters.getComponent(), is(component));
     assertThat(policyPointcutParameters.getPath(), is(TEST_REQUEST_PATH));
     assertThat(policyPointcutParameters.getMethod(), is(TEST_METHOD));
-    assertThat(policyPointcutParameters.getHeaders(), is(TEST_HEADERS));
   }
 
 }


### PR DESCRIPTION
Reverts mulesoft/mule-http-connector#397

Reverting in master, this change will still be included in `2.0.x` branch