### PR TITLE
MULE-18039: Improve performance of

### DIFF
--- a/src/main/java/org/mule/extension/http/api/listener/HttpBasicAuthenticationFilter.java
+++ b/src/main/java/org/mule/extension/http/api/listener/HttpBasicAuthenticationFilter.java
@@ -7,12 +7,12 @@
 package org.mule.extension.http.api.listener;
 
 import static java.lang.Boolean.getBoolean;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Collections.emptyMap;
 import static org.mule.extension.http.api.HttpHeaders.Names.AUTHORIZATION;
 import static org.mule.extension.http.api.HttpHeaders.Names.WWW_AUTHENTICATE;
 import static org.mule.extension.http.internal.HttpConnectorConstants.BASIC_LAX_DECODING_PROPERTY;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
-import static org.mule.runtime.core.api.config.i18n.CoreMessages.authFailedForUser;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.UNAUTHORIZED;
 
 import org.mule.extension.http.api.HttpListenerResponseAttributes;
@@ -23,7 +23,6 @@ import org.mule.runtime.api.security.Authentication;
 import org.mule.runtime.api.security.Credentials;
 import org.mule.runtime.api.security.SecurityException;
 import org.mule.runtime.api.security.SecurityProviderNotFoundException;
-import org.mule.runtime.api.security.UnauthorisedException;
 import org.mule.runtime.api.security.UnknownAuthenticationTypeException;
 import org.mule.runtime.api.security.UnsupportedAuthenticationSchemeException;
 import org.mule.runtime.api.util.MultiMap;
@@ -47,12 +46,12 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpBasicAuthenticationFilter {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpBasicAuthenticationFilter.class);
+
   private static final String HEADER_AUTHORIZATION = AUTHORIZATION.toLowerCase();
   private static final char PADDING = '=';
   private static final Decoder DECODER = Base64.getDecoder();
   private static boolean LAX_DECODING = getBoolean(BASIC_LAX_DECODING_PROPERTY);
-
-  protected static final Logger logger = LoggerFactory.getLogger(HttpBasicAuthenticationFilter.class);
 
   /**
    * Authentication realm.
@@ -85,55 +84,18 @@ public class HttpBasicAuthenticationFilter {
       throws SecurityException, SecurityProviderNotFoundException, UnknownAuthenticationTypeException {
     String header = attributes.getHeaders().get(HEADER_AUTHORIZATION);
 
-    if (logger.isDebugEnabled()) {
-      logger.debug("Authorization header: " + header);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Authorization header: " + header);
     }
 
     if ((header != null) && header.startsWith("Basic ")) {
-      String base64Token = header.substring(6);
-      if (LAX_DECODING) {
-        // commons-codec ignored the characters beyond the padding
-        base64Token = base64Token.substring(0, base64Token.lastIndexOf(PADDING) + 1);
-      }
-      String token;
-      try {
-        token = new String(DECODER.decode(base64Token.getBytes()));
-      } catch (Exception e) {
-        if (logger.isDebugEnabled()) {
-          logger.debug("Authentication request failed: " + e.toString());
-        }
-        throw new BasicUnauthorisedException(createStaticMessage("Could not decode authorization header."), e,
-                                             createUnauthenticatedMessage());
-      }
-
-      String username = "";
-      String password = "";
-      int delim = token.indexOf(":");
-
-      if (delim != -1) {
-        username = token.substring(0, delim);
-        password = token.substring(delim + 1);
-      }
-
-      Credentials credentials = authenticationHandler.createCredentialsBuilder()
-          .withUsername(username)
-          .withPassword(password.toCharArray())
-          .build();
-
-      try {
-        authenticationHandler
-            .setAuthentication(securityProviders,
-                               authenticationHandler.createAuthentication(credentials)
-                                   .setProperties(authenticationProperties(authenticationHandler)));
-      } catch (UnauthorisedException e) {
-        if (logger.isDebugEnabled()) {
-          logger.debug("Authentication request for user: " + username + " failed: " + e.toString());
-        }
-        throw new BasicUnauthorisedException(authFailedForUser(username), e, createUnauthenticatedMessage());
-      }
-
-      if (logger.isDebugEnabled()) {
-        logger.debug("Authentication success.");
+      authenticationHandler
+          .setAuthentication(securityProviders,
+                             authenticationHandler
+                                 .createAuthentication(createCredentials(authenticationHandler, decodeToken(header)))
+                                 .setProperties(authenticationProperties(authenticationHandler)));
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Authentication success.");
       }
 
     } else if (header == null) {
@@ -142,6 +104,40 @@ public class HttpBasicAuthenticationFilter {
       throw new UnsupportedAuthenticationSchemeException(createStaticMessage("Http Basic filter doesn't know how to handle header "
           + header), createUnauthenticatedMessage());
     }
+  }
+
+  private String decodeToken(String header) throws BasicUnauthorisedException {
+    String base64Token = header.substring(6);
+    if (LAX_DECODING) {
+      // commons-codec ignored the characters beyond the padding
+      base64Token = base64Token.substring(0, base64Token.lastIndexOf(PADDING) + 1);
+    }
+
+    try {
+      return new String(DECODER.decode(base64Token), US_ASCII);
+    } catch (Exception e) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Authentication request failed: " + e.toString());
+      }
+      throw new BasicUnauthorisedException(createStaticMessage("Could not decode authorization header."), e,
+                                           createUnauthenticatedMessage());
+    }
+  }
+
+  private Credentials createCredentials(AuthenticationHandler authenticationHandler, String token) {
+    String username = "";
+    String password = "";
+    int delim = token.indexOf(":");
+
+    if (delim != -1) {
+      username = token.substring(0, delim);
+      password = token.substring(delim + 1);
+    }
+
+    return authenticationHandler.createCredentialsBuilder()
+        .withUsername(username)
+        .withPassword(password.toCharArray())
+        .build();
   }
 
   private Map<String, Object> authenticationProperties(AuthenticationHandler authenticationHandler) {

--- a/src/main/java/org/mule/extension/http/api/listener/HttpBasicAuthenticationFilter.java
+++ b/src/main/java/org/mule/extension/http/api/listener/HttpBasicAuthenticationFilter.java
@@ -84,9 +84,7 @@ public class HttpBasicAuthenticationFilter {
       throws SecurityException, SecurityProviderNotFoundException, UnknownAuthenticationTypeException {
     String header = attributes.getHeaders().get(HEADER_AUTHORIZATION);
 
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Authorization header: " + header);
-    }
+    LOGGER.debug("Authorization header: {}", header);
 
     if ((header != null) && header.startsWith("Basic ")) {
       authenticationHandler
@@ -94,10 +92,7 @@ public class HttpBasicAuthenticationFilter {
                              authenticationHandler
                                  .createAuthentication(createCredentials(authenticationHandler, decodeToken(header)))
                                  .setProperties(authenticationProperties(authenticationHandler)));
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("Authentication success.");
-      }
-
+      LOGGER.debug("Authentication success.");
     } else if (header == null) {
       throw new BasicUnauthorisedException(null, "HTTP basic authentication", "HTTP listener", createUnauthenticatedMessage());
     } else {
@@ -117,7 +112,7 @@ public class HttpBasicAuthenticationFilter {
       return new String(DECODER.decode(base64Token), US_ASCII);
     } catch (Exception e) {
       if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("Authentication request failed: " + e.toString());
+        LOGGER.debug("Authentication request failed: {}", e.toString());
       }
       throw new BasicUnauthorisedException(createStaticMessage("Could not decode authorization header."), e,
                                            createUnauthenticatedMessage());

--- a/src/main/java/org/mule/extension/http/internal/filter/BasicUnauthorisedException.java
+++ b/src/main/java/org/mule/extension/http/internal/filter/BasicUnauthorisedException.java
@@ -14,7 +14,9 @@ import org.mule.runtime.api.security.UnauthorisedException;
 
 public class BasicUnauthorisedException extends UnauthorisedException implements ErrorMessageAwareException {
 
-  private Message errorMessage;
+  private static final long serialVersionUID = -5707279260743243251L;
+
+  private final Message errorMessage;
 
   public BasicUnauthorisedException(I18nMessage message, Message errorMessage) {
     super(message);


### PR DESCRIPTION
`HttpBasicAuthenticationFilter#authenticate`

* Part 1: Token decoding

```
BasicAuthDecodeBenchmark.newWay                                      avgt   10   195.854 ±   2.988   ns/op
BasicAuthDecodeBenchmark.newWay:·gc.alloc.rate                       avgt   10  4448.987 ±  68.609  MB/sec
BasicAuthDecodeBenchmark.newWay:·gc.alloc.rate.norm                  avgt   10   320.000 ±   0.001    B/op
BasicAuthDecodeBenchmark.newWay:·gc.churn.PS_Eden_Space              avgt   10  4467.929 ±  70.765  MB/sec
BasicAuthDecodeBenchmark.newWay:·gc.churn.PS_Eden_Space.norm         avgt   10   321.365 ±   2.294    B/op
BasicAuthDecodeBenchmark.newWay:·gc.churn.PS_Survivor_Space          avgt   10     0.192 ±   0.016  MB/sec
BasicAuthDecodeBenchmark.newWay:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.014 ±   0.001    B/op
BasicAuthDecodeBenchmark.newWay:·gc.count                            avgt   10  1256.000            counts
BasicAuthDecodeBenchmark.newWay:·gc.time                             avgt   10   957.000                ms
BasicAuthDecodeBenchmark.oldWay                                      avgt   10   200.634 ±  20.236   ns/op
BasicAuthDecodeBenchmark.oldWay:·gc.alloc.rate                       avgt   10  3051.803 ± 281.800  MB/sec
BasicAuthDecodeBenchmark.oldWay:·gc.alloc.rate.norm                  avgt   10   224.000 ±   0.001    B/op
BasicAuthDecodeBenchmark.oldWay:·gc.churn.PS_Eden_Space              avgt   10  3061.355 ± 272.183  MB/sec
BasicAuthDecodeBenchmark.oldWay:·gc.churn.PS_Eden_Space.norm         avgt   10   224.734 ±   1.627    B/op
BasicAuthDecodeBenchmark.oldWay:·gc.churn.PS_Survivor_Space          avgt   10     0.160 ±   0.027  MB/sec
BasicAuthDecodeBenchmark.oldWay:·gc.churn.PS_Survivor_Space.norm     avgt   10     0.012 ±   0.002    B/op
BasicAuthDecodeBenchmark.oldWay:·gc.count                            avgt   10  1269.000            counts
BasicAuthDecodeBenchmark.oldWay:·gc.time                             avgt   10   959.000                ms
```