### PR TITLE
MULE-18241: `mule.http.client.encodeUriParams` wrongly encodes spaces in

### DIFF
--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsEncodingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsEncodingTestCase.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mule.extension.http.api.HttpMessageBuilder.refreshSystemProperties;
 import static org.mule.extension.http.internal.HttpConnectorConstants.ENCODE_URI_PARAMS_PROPERTY;
+
 import org.mule.tck.junit4.rule.SystemProperty;
 
 import org.junit.AfterClass;
@@ -33,9 +34,23 @@ public class HttpRequestUriParamsEncodingTestCase extends HttpRequestUriParamsTe
 
   @Override
   public void uriParamsContainsReservedUriCharacter() throws Exception {
-    flowRunner("reservedUriCharacter").withPayload(TEST_MESSAGE)
-        .withVariable("paramName", "testParam").withVariable("paramValue", "$a/word%here\\").run();
+    flowRunner("reservedUriCharacter")
+        .withPayload(TEST_MESSAGE)
+        .withVariable("paramName", "testParam")
+        .withVariable("paramValue", "$a/word%here\\")
+        .run();
 
     assertThat(uri, equalTo("/testPath/%24a%2Fword%25here%5C"));
+  }
+
+  @Override
+  public void uriParamsContainsSpaces() throws Exception {
+    flowRunner("spaceUriCharacter")
+        .withPayload(TEST_MESSAGE)
+        .withVariable("param name", "testParam")
+        .withVariable("paramValue", "a word+here")
+        .run();
+
+    assertThat(uri, equalTo("/testPath/a%20word%2Bhere"));
   }
 }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
@@ -18,6 +18,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.qameta.allure.Issue;
+
 public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
 
   @Rule
@@ -64,16 +66,34 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void uriParamsContainsReservedUriCharacter() throws Exception {
-    flowRunner("reservedUriCharacter").withPayload(TEST_MESSAGE)
-        .withVariable("paramName", "testParam").withVariable("paramValue", "$a").run();
+    flowRunner("reservedUriCharacter")
+        .withPayload(TEST_MESSAGE)
+        .withVariable("paramName", "testParam")
+        .withVariable("paramValue", "$a")
+        .run();
 
     assertThat(uri, equalTo("/testPath/$a"));
   }
 
   @Test
+  @Issue("MULE-18241")
+  public void uriParamsContainsSpaces() throws Exception {
+    flowRunner("spaceUriCharacter")
+        .withPayload(TEST_MESSAGE)
+        .withVariable("param name", "testParam")
+        .withVariable("paramValue", "a word+here")
+        .run();
+
+    assertThat(uri, equalTo("/testPath/a%20word+here"));
+  }
+
+  @Test
   public void uriParamsWithRegEx() throws Exception {
-    flowRunner("regEx").withPayload(TEST_MESSAGE)
-        .withVariable("paramName", "[1-9]").withVariable("paramValue", "abc").run();
+    flowRunner("regEx")
+        .withPayload(TEST_MESSAGE)
+        .withVariable("paramName", "[1-9]")
+        .withVariable("paramValue", "abc")
+        .run();
 
     assertThat(uri, equalTo("/testPath/abc"));
   }

--- a/src/test/resources/http-request-uri-params-config.xml
+++ b/src/test/resources/http-request-uri-params-config.xml
@@ -37,7 +37,7 @@
     <flow name="uriParamNull">
         <http:request config-ref="config" path="testPath/{testParam1}/{testParam2}">
             <http:uri-params>
-                #[mel:['testParam1' : 'testValue1' , 'testParam2' : payload]]
+                #[{'testParam1' : 'testValue1' , 'testParam2' : payload}]
             </http:uri-params>
         </http:request>
     </flow>
@@ -46,6 +46,14 @@
         <http:request config-ref="config" path="testPath/{testParam}">
             <http:uri-params>
                 #[(vars.paramName): vars.paramValue]
+            </http:uri-params>
+        </http:request>
+    </flow>
+
+    <flow name="spaceUriCharacter">
+        <http:request config-ref="config" path="testPath/{testParam}">
+            <http:uri-params>
+                #[(vars['param name']): vars.paramValue]
             </http:uri-params>
         </http:request>
     </flow>


### PR DESCRIPTION
uri params