### PR TITLE
MULE-18307: Using "payload" in an expression for refreshTokenWhen property results in an Error

### DIFF
--- a/src/main/java/org/mule/extension/http/api/request/validator/FailureStatusCodeValidator.java
+++ b/src/main/java/org/mule/extension/http/api/request/validator/FailureStatusCodeValidator.java
@@ -23,16 +23,16 @@ import java.util.function.Consumer;
 public class FailureStatusCodeValidator extends RangeStatusCodeValidator {
 
   @Override
-  public void validate(Result<InputStream, HttpResponseAttributes> result, HttpRequest request) {
+  public void validate(Result<Object, HttpResponseAttributes> result, HttpRequest request) {
     validate(result, status -> throwValidationException(result, request, status));
   }
 
   @Override
-  public void validate(Result<InputStream, HttpResponseAttributes> result, HttpRequest request, StreamingHelper streamingHelper) {
+  public void validate(Result<Object, HttpResponseAttributes> result, HttpRequest request, StreamingHelper streamingHelper) {
     validate(result, status -> throwValidationException(toMessage(result, streamingHelper), request, status));
   }
 
-  private void validate(Result<InputStream, HttpResponseAttributes> result, Consumer<Integer> ifInvalid) {
+  private void validate(Result<Object, HttpResponseAttributes> result, Consumer<Integer> ifInvalid) {
     int status = result.getAttributes().get().getStatusCode();
 
     if (belongs(status)) {

--- a/src/main/java/org/mule/extension/http/api/request/validator/RangeStatusCodeValidator.java
+++ b/src/main/java/org/mule/extension/http/api/request/validator/RangeStatusCodeValidator.java
@@ -83,7 +83,7 @@ public abstract class RangeStatusCodeValidator implements ResponseValidator {
    * @throws ResponseValidatorTypedException
    * @throws ResponseValidatorException
    */
-  protected void throwValidationException(Result<InputStream, HttpResponseAttributes> result, HttpRequest request, int status) {
+  protected void throwValidationException(Result<Object, HttpResponseAttributes> result, HttpRequest request, int status) {
     getErrorByCode(status)
         .map(error -> {
           throw new ResponseValidatorTypedException(errorMessageGenerator.createFrom(request, status), error, result);
@@ -110,9 +110,9 @@ public abstract class RangeStatusCodeValidator implements ResponseValidator {
                      () -> new ResponseValidatorException(errorMessageGenerator.createFrom(request, status), message));
   }
 
-  protected Message toMessage(Result<InputStream, HttpResponseAttributes> result, StreamingHelper streamingHelper) {
+  protected Message toMessage(Result<Object, HttpResponseAttributes> result, StreamingHelper streamingHelper) {
     return Message.builder()
-        .value(streamingHelper.resolveCursorProvider(result.getOutput()))
+        .value(result.getOutput())
         .attributesValue(result.getAttributes().get())
         .mediaType(result.getMediaType().orElse(ANY))
         .build();

--- a/src/main/java/org/mule/extension/http/api/request/validator/ResponseValidator.java
+++ b/src/main/java/org/mule/extension/http/api/request/validator/ResponseValidator.java
@@ -31,7 +31,7 @@ public interface ResponseValidator {
    *         specific error type.
    * @deprecated use {@link #validate(Result, HttpRequest, StreamingHelper)} instead
    */
-  void validate(Result<InputStream, HttpResponseAttributes> result, HttpRequest request);
+  void validate(Result<Object, HttpResponseAttributes> result, HttpRequest request);
 
   /**
    * Validates whether an HTTP response result should be accepted or not, failing in that case. By default this will behave as
@@ -46,7 +46,7 @@ public interface ResponseValidator {
    * @throws ResponseValidatorException if the message is not considered valid and the response validator does not relates to an
    *         specific error type.
    */
-  default void validate(Result<InputStream, HttpResponseAttributes> result, HttpRequest request,
+  default void validate(Result<Object, HttpResponseAttributes> result, HttpRequest request,
                         StreamingHelper streamingHelper) {
     validate(result, request);
   }

--- a/src/main/java/org/mule/extension/http/api/request/validator/ResponseValidatorException.java
+++ b/src/main/java/org/mule/extension/http/api/request/validator/ResponseValidatorException.java
@@ -39,7 +39,7 @@ public class ResponseValidatorException extends MuleRuntimeException implements 
    * @deprecated use {@link #ResponseValidatorException(String, Message)} instead.
    */
   @Deprecated
-  public ResponseValidatorException(String message, Result<InputStream, HttpResponseAttributes> result) {
+  public ResponseValidatorException(String message, Result<Object, HttpResponseAttributes> result) {
     this(message);
     this.errorMessage = Message.builder()
         .value(result.getOutput())

--- a/src/main/java/org/mule/extension/http/api/request/validator/ResponseValidatorTypedException.java
+++ b/src/main/java/org/mule/extension/http/api/request/validator/ResponseValidatorTypedException.java
@@ -39,7 +39,7 @@ public class ResponseValidatorTypedException extends ModuleException implements 
    * @deprecated use {{@link #ResponseValidatorTypedException(String, HttpError, Message)}} instead
    */
   @Deprecated
-  public ResponseValidatorTypedException(String message, HttpError error, Result<InputStream, HttpResponseAttributes> result) {
+  public ResponseValidatorTypedException(String message, HttpError error, Result<Object, HttpResponseAttributes> result) {
     this(message, error);
     this.errorMessage = Message.builder()
         .value(result.getOutput())

--- a/src/main/java/org/mule/extension/http/api/request/validator/SuccessStatusCodeValidator.java
+++ b/src/main/java/org/mule/extension/http/api/request/validator/SuccessStatusCodeValidator.java
@@ -30,16 +30,16 @@ public class SuccessStatusCodeValidator extends RangeStatusCodeValidator {
   }
 
   @Override
-  public void validate(Result<InputStream, HttpResponseAttributes> result, HttpRequest request) {
+  public void validate(Result<Object, HttpResponseAttributes> result, HttpRequest request) {
     validate(result, status -> throwValidationException(result, request, status));
   }
 
   @Override
-  public void validate(Result<InputStream, HttpResponseAttributes> result, HttpRequest request, StreamingHelper streamingHelper) {
+  public void validate(Result<Object, HttpResponseAttributes> result, HttpRequest request, StreamingHelper streamingHelper) {
     validate(result, status -> throwValidationException(toMessage(result, streamingHelper), request, status));
   }
 
-  private void validate(Result<InputStream, HttpResponseAttributes> result, Consumer<Integer> ifInvalid) {
+  private void validate(Result<Object, HttpResponseAttributes> result, Consumer<Integer> ifInvalid) {
     int status = result.getAttributes().get().getStatusCode();
 
     if (!belongs(status)) {

--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
@@ -111,7 +111,7 @@ public class HttpRequestOperations implements Initialisable, Disposable {
                       CorrelationInfo correlationInfo,
                       NotificationEmitter notificationEmitter,
                       StreamingHelper streamingHelper,
-                      CompletionCallback<InputStream, HttpResponseAttributes> callback) {
+                      CompletionCallback<Object, HttpResponseAttributes> callback) {
     try {
       HttpRequesterRequestBuilder resolvedBuilder = requestBuilder != null ? requestBuilder : DEFAULT_REQUEST_BUILDER;
 

--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
@@ -104,7 +104,7 @@ public class HttpRequester {
                         int responseTimeout, ResponseValidator responseValidator,
                         TransformationService transformationService, HttpRequesterRequestBuilder requestBuilder,
                         boolean checkRetry, MuleContext muleContext, Scheduler scheduler, NotificationEmitter notificationEmitter,
-                        StreamingHelper streamingHelper, CompletionCallback<InputStream, HttpResponseAttributes> callback,
+                        StreamingHelper streamingHelper, CompletionCallback<Object, HttpResponseAttributes> callback,
                         Map<String, List<String>> injectedHeaders) {
     doRequestWithRetry(client, config, uri, method, streamingMode, sendBodyMode, followRedirects, authentication, responseTimeout,
                        responseValidator, transformationService, requestBuilder, checkRetry, muleContext, scheduler,
@@ -122,7 +122,7 @@ public class HttpRequester {
                                   boolean checkRetry, MuleContext muleContext, Scheduler scheduler,
                                   NotificationEmitter notificationEmitter,
                                   StreamingHelper streamingHelper,
-                                  CompletionCallback<InputStream, HttpResponseAttributes> callback, HttpRequest httpRequest,
+                                  CompletionCallback<Object, HttpResponseAttributes> callback, HttpRequest httpRequest,
                                   int retryCount, Map<String, List<String>> injectedHeaders) {
     fireNotification(notificationEmitter, REQUEST_START, () -> HttpRequestNotificationData.from(httpRequest),
                      REQUEST_NOTIFICATION_DATA_TYPE);
@@ -134,8 +134,8 @@ public class HttpRequester {
               fireNotification(notificationEmitter, REQUEST_COMPLETE, () -> HttpResponseNotificationData.from(response),
                                RESPONSE_NOTIFICATION_DATA_TYPE);
 
-              Result<InputStream, HttpResponseAttributes> result =
-                  RESPONSE_TO_RESULT.convert(config, muleContext, response, httpRequest.getUri());
+              Result<Object, HttpResponseAttributes> result =
+                  RESPONSE_TO_RESULT.convert(config, muleContext, response, httpRequest.getUri(), streamingHelper);
 
               resendRequest(result, checkRetry, authentication, () -> {
                 scheduler.submit(() -> consumePayload(result));


### PR DESCRIPTION
Changed the HttpResponseToResult so that the result for a request of the HttpRequester is a repeatable stream because when the payload was read to decide whether to resend or not the request it was being consumed.