### PR TITLE
MULE-18307: Using "payload" in an expression for refreshTokenWhen property results in an Error

### DIFF
--- a/src/main/java/org/mule/extension/http/api/request/authentication/HttpRequestAuthentication.java
+++ b/src/main/java/org/mule/extension/http/api/request/authentication/HttpRequestAuthentication.java
@@ -44,7 +44,7 @@ public interface HttpRequestAuthentication {
    * @deprecated implement {@link #retryIfShould(Result, Runnable, Runnable)} that allows to do a non-blocking retry.
    */
   @Deprecated
-  boolean shouldRetry(Result<Object, HttpResponseAttributes> firstAttemptResult) throws MuleException;
+  boolean shouldRetry(Result<? extends Object, HttpResponseAttributes> firstAttemptResult) throws MuleException;
 
   /**
    * Detects if there was an authentication failure in the response. After sending an HTTP request and creating a result with the
@@ -57,7 +57,7 @@ public interface HttpRequestAuthentication {
    * @param retryCallback the callback that performs the retry of the request.
    * @param notRetryCallback the callback that perfroms any necessary steps for not retrying the request.
    */
-  default void retryIfShould(Result<Object, HttpResponseAttributes> firstAttemptResult, Runnable retryCallback,
+  default void retryIfShould(Result<? extends Object, HttpResponseAttributes> firstAttemptResult, Runnable retryCallback,
                              Runnable notRetryCallback) {
     try {
       if (shouldRetry(firstAttemptResult)) {

--- a/src/main/java/org/mule/extension/http/api/request/authentication/UsernamePasswordAuthentication.java
+++ b/src/main/java/org/mule/extension/http/api/request/authentication/UsernamePasswordAuthentication.java
@@ -51,7 +51,7 @@ public abstract class UsernamePasswordAuthentication implements HttpAuthenticati
   }
 
   @Override
-  public boolean shouldRetry(Result<Object, HttpResponseAttributes> firstAttemptResult) throws MuleException {
+  public boolean shouldRetry(Result<? extends Object, HttpResponseAttributes> firstAttemptResult) throws MuleException {
     return false;
   }
 

--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
@@ -14,6 +14,7 @@ import static org.mule.runtime.extension.api.annotation.param.MediaType.ANY;
 import static org.mule.runtime.http.api.utils.HttpEncoderDecoderUtils.encodeSpaces;
 
 import org.mule.extension.http.api.HttpResponseAttributes;
+import org.mule.extension.http.api.error.HttpErrorMessageGenerator;
 import org.mule.extension.http.api.request.builder.HttpRequesterRequestBuilder;
 import org.mule.extension.http.api.request.client.UriParameters;
 import org.mule.extension.http.api.request.validator.ResponseValidator;
@@ -65,9 +66,9 @@ public class HttpRequestOperations implements Initialisable, Disposable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestOperations.class);
   private static final int WAIT_FOR_EVER = MAX_VALUE;
-  private static final SuccessStatusCodeValidator DEFAULT_STATUS_CODE_VALIDATOR = new SuccessStatusCodeValidator("0..399");
-  private static final HttpRequesterRequestBuilder DEFAULT_REQUEST_BUILDER = new HttpRequesterRequestBuilder();
-  private static final HttpRequester REQUESTER = new HttpRequester();
+  private SuccessStatusCodeValidator defaultStatusCodeValidator;
+  private HttpRequesterRequestBuilder defaultRequestBuilder;
+  private HttpRequester httpRequester;
 
   @Inject
   private MuleContext muleContext;
@@ -113,7 +114,7 @@ public class HttpRequestOperations implements Initialisable, Disposable {
                       StreamingHelper streamingHelper,
                       CompletionCallback<InputStream, HttpResponseAttributes> callback) {
     try {
-      HttpRequesterRequestBuilder resolvedBuilder = requestBuilder != null ? requestBuilder : DEFAULT_REQUEST_BUILDER;
+      HttpRequesterRequestBuilder resolvedBuilder = requestBuilder != null ? requestBuilder : defaultRequestBuilder;
 
       handleCursor(resolvedBuilder);
 
@@ -132,13 +133,15 @@ public class HttpRequestOperations implements Initialisable, Disposable {
 
       int resolvedTimeout = resolveResponseTimeout(overrides.getResponseTimeout());
       ResponseValidator responseValidator = responseValidationSettings.getResponseValidator();
-      responseValidator = responseValidator != null ? responseValidator : DEFAULT_STATUS_CODE_VALIDATOR;
+      responseValidator = responseValidator != null ? responseValidator : defaultStatusCodeValidator;
 
       LOGGER.debug("Sending '{}' request to '{}'.", method, resolvedUri);
-      REQUESTER.doRequest(client, config, resolvedUri, method, overrides.getRequestStreamingMode(), overrides.getSendBodyMode(),
-                          overrides.getFollowRedirects(), client.getDefaultAuthentication(), resolvedTimeout, responseValidator,
-                          transformationService, resolvedBuilder, true, muleContext, scheduler, notificationEmitter,
-                          streamingHelper, callback, injectedHeaders);
+      httpRequester.doRequest(client, config, resolvedUri, method, overrides.getRequestStreamingMode(),
+                              overrides.getSendBodyMode(),
+                              overrides.getFollowRedirects(), client.getDefaultAuthentication(), resolvedTimeout,
+                              responseValidator,
+                              transformationService, resolvedBuilder, true, muleContext, scheduler, notificationEmitter,
+                              streamingHelper, callback, injectedHeaders);
     } catch (Throwable t) {
       callback.error(t instanceof Exception ? (Exception) t : new DefaultMuleException(t));
     }
@@ -200,6 +203,9 @@ public class HttpRequestOperations implements Initialisable, Disposable {
 
   @Override
   public void initialise() throws InitialisationException {
+    defaultStatusCodeValidator = new SuccessStatusCodeValidator("0..399");
+    defaultRequestBuilder = new HttpRequesterRequestBuilder();
+    httpRequester = new HttpRequester(new HttpRequestFactory(), new HttpResponseToResult(), new HttpErrorMessageGenerator());
     this.scheduler = schedulerService.ioScheduler();
   }
 

--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
@@ -40,6 +40,8 @@ import org.mule.runtime.api.exception.MuleRuntimeException;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.scheduler.Scheduler;
+import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.runtime.api.streaming.bytes.CursorStream;
 import org.mule.runtime.api.transformation.TransformationService;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.util.IOUtils;
@@ -49,6 +51,7 @@ import org.mule.runtime.extension.api.runtime.operation.Result;
 import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
 import org.mule.runtime.extension.api.runtime.streaming.StreamingHelper;
 import org.mule.runtime.http.api.client.auth.HttpAuthentication;
+import org.mule.runtime.http.api.domain.entity.HttpEntity;
 import org.mule.runtime.http.api.domain.message.request.HttpRequest;
 
 import java.io.IOException;
@@ -81,9 +84,9 @@ public class HttpRequester {
   private static final DataType REQUEST_NOTIFICATION_DATA_TYPE = DataType.fromType(HttpRequestNotificationData.class);
   private static final DataType RESPONSE_NOTIFICATION_DATA_TYPE = DataType.fromType(HttpResponseNotificationData.class);
 
-  private static final HttpRequestFactory EVENT_TO_HTTP_REQUEST = new HttpRequestFactory();
-  private static final HttpResponseToResult RESPONSE_TO_RESULT = new HttpResponseToResult();
-  private static final HttpErrorMessageGenerator ERROR_MESSAGE_GENERATOR = new HttpErrorMessageGenerator();
+  private final HttpRequestFactory httpRequestFactory;
+  private final HttpResponseToResult httpResponseToResult;
+  private final HttpErrorMessageGenerator httpErrorMessageGenerator;
 
   private static final Method fireNotificationMethod;
 
@@ -98,6 +101,13 @@ public class HttpRequester {
     fireNotificationMethod = fireLazy;
   }
 
+  public HttpRequester(HttpRequestFactory httpRequestFactory, HttpResponseToResult httpResponseToResult,
+                       HttpErrorMessageGenerator httpErrorMessageGenerator) {
+    this.httpRequestFactory = httpRequestFactory;
+    this.httpResponseToResult = httpResponseToResult;
+    this.httpErrorMessageGenerator = httpErrorMessageGenerator;
+  }
+
   public void doRequest(HttpExtensionClient client, HttpRequesterConfig config, String uri, String method,
                         HttpStreamingType streamingMode, HttpSendBodyMode sendBodyMode,
                         boolean followRedirects, HttpRequestAuthentication authentication,
@@ -109,8 +119,8 @@ public class HttpRequester {
     doRequestWithRetry(client, config, uri, method, streamingMode, sendBodyMode, followRedirects, authentication, responseTimeout,
                        responseValidator, transformationService, requestBuilder, checkRetry, muleContext, scheduler,
                        notificationEmitter, streamingHelper, callback,
-                       EVENT_TO_HTTP_REQUEST.create(config, uri, method, streamingMode, sendBodyMode, transformationService,
-                                                    requestBuilder, authentication, injectedHeaders),
+                       httpRequestFactory.create(config, uri, method, streamingMode, sendBodyMode, transformationService,
+                                                 requestBuilder, authentication, injectedHeaders),
                        RETRY_ATTEMPTS, injectedHeaders);
   }
 
@@ -134,8 +144,10 @@ public class HttpRequester {
               fireNotification(notificationEmitter, REQUEST_COMPLETE, () -> HttpResponseNotificationData.from(response),
                                RESPONSE_NOTIFICATION_DATA_TYPE);
 
+              HttpEntity entity = response.getEntity();
+
               Result<InputStream, HttpResponseAttributes> result =
-                  RESPONSE_TO_RESULT.convert(config, muleContext, response, httpRequest.getUri());
+                  makeResult(config, muleContext, streamingHelper, httpRequest, response, entity);
 
               resendRequest(result, checkRetry, authentication, () -> {
                 scheduler.submit(() -> consumePayload(result));
@@ -145,7 +157,11 @@ public class HttpRequester {
                           streamingHelper, callback, injectedHeaders);
               }, () -> {
                 responseValidator.validate(result, httpRequest, streamingHelper);
-                callback.success(result);
+
+                Result<InputStream, HttpResponseAttributes> freshResult =
+                    makeResult(config, muleContext, streamingHelper, httpRequest, response, entity);
+
+                callback.success(freshResult);
               });
             } catch (Exception e) {
               callback.error(e);
@@ -164,12 +180,28 @@ public class HttpRequester {
 
             logger.error(getErrorMessage(httpRequest));
             HttpError error = exception instanceof TimeoutException ? TIMEOUT : CONNECTIVITY;
-            callback.error(new HttpRequestFailedException(createStaticMessage(ERROR_MESSAGE_GENERATOR
+            callback.error(new HttpRequestFailedException(createStaticMessage(httpErrorMessageGenerator
                 .createFrom(httpRequest,
                             getExceptionMessage(exception))),
                                                           exception, error));
           }
         });
+  }
+
+  private Result<InputStream, HttpResponseAttributes> makeResult(HttpRequesterConfig config, MuleContext muleContext,
+                                                                 StreamingHelper streamingHelper, HttpRequest httpRequest,
+                                                                 org.mule.runtime.http.api.domain.message.response.HttpResponse response,
+                                                                 HttpEntity entity) {
+    Object resolved = streamingHelper.resolveCursorProvider(entity.getContent());
+
+    if (resolved instanceof CursorProvider) {
+      CursorProvider<CursorStream> payloadBodyCursorProvider = (CursorProvider<CursorStream>) resolved;
+      return httpResponseToResult.convert(config, muleContext, response, entity, payloadBodyCursorProvider::openCursor,
+                                          httpRequest.getUri());
+    }
+
+    return httpResponseToResult.convert(config, muleContext, response, entity, () -> (InputStream) resolved,
+                                        httpRequest.getUri());
   }
 
   private String getExceptionMessage(Throwable t) {

--- a/src/main/java/org/mule/extension/http/internal/request/HttpResponseToResult.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpResponseToResult.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Component that transforms an HTTP response to a proper {@link Result}.
@@ -56,18 +57,9 @@ public class HttpResponseToResult {
 
   private final Function<String, MediaType> parseMediaType = memoize(ctv -> parseMediaType(ctv), new ConcurrentHashMap<>());
 
-  public Result<InputStream, HttpResponseAttributes> convert(HttpRequesterCookieConfig config, MuleContext muleContext,
-                                                             HttpResponse response, URI uri) {
-    String responseContentType = response.getHeaderValue(CONTENT_TYPE);
-
-    HttpEntity entity = response.getEntity();
-
-    if (isEmpty(responseContentType) && !empty(entity)) {
-      // RFC-2616 specifies application/octet-stream as default when none is received
-      responseContentType = BINARY_CONTENT_TYPE;
-    }
-
-    MediaType responseMediaType = getMediaType(responseContentType, getDefaultEncoding(muleContext));
+  Result<InputStream, HttpResponseAttributes> convert(HttpRequesterCookieConfig config, MuleContext muleContext,
+                                                      HttpResponse response, HttpEntity entity,
+                                                      Supplier<InputStream> payloadSupplier, URI uri) {
 
     if (config.isEnableCookies()) {
       processCookies(config, response, uri);
@@ -76,12 +68,12 @@ public class HttpResponseToResult {
     HttpResponseAttributes responseAttributes = createAttributes(response);
 
     final Result.Builder<InputStream, HttpResponseAttributes> builder = Result.builder();
-    builder.mediaType(responseMediaType);
+    builder.mediaType(getMediaType(getResponseContentType(response, entity), getDefaultEncoding(muleContext)));
     if (entity.getLength().isPresent()) {
       builder.length(entity.getLength().get());
     }
 
-    return builder.output(entity.getContent()).attributes(responseAttributes).build();
+    return builder.output(payloadSupplier.get()).attributes(responseAttributes).build();
   }
 
   private boolean empty(HttpEntity entity) {
@@ -153,4 +145,13 @@ public class HttpResponseToResult {
     STRICT_CONTENT_TYPE = parseBoolean(getProperty(SYSTEM_PROPERTY_PREFIX + "strictContentType"));
   }
 
+  private String getResponseContentType(HttpResponse response, HttpEntity entity) {
+    String responseContentType = response.getHeaderValue(CONTENT_TYPE);
+
+    if (isEmpty(responseContentType) && !empty(entity)) {
+      // RFC-2616 specifies application/octet-stream as default when none is received
+      responseContentType = BINARY_CONTENT_TYPE;
+    }
+    return responseContentType;
+  }
 }


### PR DESCRIPTION
Use repeatable streams when posible in order to prevent the auth mechanism from consuming the payload before it is returned