### PR TITLE
MULE-18307: Using "payload" in an expression for refreshTokenWhen property results in an Error

### DIFF
--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
@@ -192,7 +192,7 @@ public class HttpRequester {
 
   private Supplier<Object> resultInputStreamSupplier(StreamingHelper streamingHelper, HttpEntity entity,
                                                      HttpRequestAuthentication authentication) {
-    if (authentication != null && !authentication.readsAuthenticatedResponseBody()) {
+    if (authentication == null || !authentication.readsAuthenticatedResponseBody()) {
       return entity::getContent;
     }
 

--- a/src/test/java/org/mule/extension/http/internal/request/HttpRequesterAuthConsumesPayloadTestCase.java
+++ b/src/test/java/org/mule/extension/http/internal/request/HttpRequesterAuthConsumesPayloadTestCase.java
@@ -284,8 +284,8 @@ public class HttpRequesterAuthConsumesPayloadTestCase {
 
     // When
     httpRequester.doRequest(client, config, uri, "dummyMethod", null, null, false, authentication, 0, responseValidator, null,
-        requestBuilder, checkRetry, muleContext, null, notificationEmitter, streamingHelper, callback,
-        injectedHeaders);
+                            requestBuilder, checkRetry, muleContext, null, notificationEmitter, streamingHelper, callback,
+                            injectedHeaders);
 
     // Then
     verify(streamingHelper, never()).resolveCursorProvider(entity.getContent());


### PR DESCRIPTION
The condition that decided whether to make the body repeatable was not taking the possibility of no authentication into account.