### PR TITLE
HTTPC-134: Fixing tests by considering the new expected error message…

### DIFF
--- a/src/test/java/org/mule/test/http/functional/AbstractHttpTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/AbstractHttpTestCase.java
@@ -25,7 +25,12 @@ import org.junit.Rule;
 public abstract class AbstractHttpTestCase extends MuleArtifactFunctionalTestCase {
 
   protected static final int DEFAULT_TIMEOUT = 1000;
-  protected static final String J8_SSL_ERROR_RESPONSE = "General SSLEngine problem";
+
+  // Expected validation error message for JDK 1.8.0_262.
+  protected static final String J8_262_SSL_ERROR_RESPONSE = "General SSLEngine problem";
+  // Expected validation error message for JDK 1.8.0_275.
+  protected static final String J8_275_SSL_ERROR_RESPONSE = "Certificate signature validation failed";
+  // Expected validation error message for JDK 11.
   protected static final String J11_SSL_ERROR_RESPONSE = "PKIX path building failed";
 
   @Rule

--- a/src/test/java/org/mule/test/http/functional/listener/HttpListenerCustomTlsConfigMultipleKeysTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/listener/HttpListenerCustomTlsConfigMultipleKeysTestCase.java
@@ -41,7 +41,9 @@ public class HttpListenerCustomTlsConfigMultipleKeysTestCase extends AbstractHtt
 
   @Test
   public void rejectsConnectionWithInvalidCertificate() throws Exception {
-    expectedException.expectMessage(anyOf(containsString(J8_SSL_ERROR_RESPONSE), containsString("PKIX path validation failed")));
+    expectedException.expectMessage(anyOf(containsString(J8_262_SSL_ERROR_RESPONSE),
+                                          containsString(J8_275_SSL_ERROR_RESPONSE),
+                                          containsString(J11_SSL_ERROR_RESPONSE)));
     flowRunner("testFlowClientWithoutCertificate").withPayload(TEST_MESSAGE).run();
   }
 

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestTlsInsecureTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestTlsInsecureTestCase.java
@@ -69,7 +69,8 @@ public class HttpRequestTlsInsecureTestCase extends AbstractHttpTestCase {
   public void secureRequest() throws Exception {
     expectedError.expectCause(instanceOf(IOException.class));
     expectedError
-        .expectCause(anyOf(hasMessage(containsString(J8_SSL_ERROR_RESPONSE)),
+        .expectCause(anyOf(hasMessage(containsString(J8_262_SSL_ERROR_RESPONSE)),
+                           hasMessage(containsString("No trusted certificate found")),
                            hasMessage(containsString(J11_SSL_ERROR_RESPONSE))));
     flowRunner("testSecureRequest").withPayload(TEST_PAYLOAD).run();
   }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestValidateCertificateTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestValidateCertificateTestCase.java
@@ -37,7 +37,9 @@ public class HttpRequestValidateCertificateTestCase extends AbstractHttpRequestT
 
   @Test
   public void rejectsMissingCertificate() throws Exception {
-    expectedException.expectMessage(anyOf(containsString(J8_SSL_ERROR_RESPONSE), containsString(J11_SSL_ERROR_RESPONSE)));
+    expectedException.expectMessage(anyOf(containsString(J8_262_SSL_ERROR_RESPONSE),
+                                          containsString(J8_275_SSL_ERROR_RESPONSE),
+                                          containsString(J11_SSL_ERROR_RESPONSE)));
     flowRunner("missingCertFlow").withPayload(TEST_MESSAGE).run();
   }
 

--- a/src/test/java/org/mule/test/http/functional/tls/HttpTlsContextInsecureModeTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/tls/HttpTlsContextInsecureModeTestCase.java
@@ -69,7 +69,9 @@ public class HttpTlsContextInsecureModeTestCase extends AbstractHttpTlsContextTe
     HttpResponse response = executeGetRequest(secureModeInvalidUrl);
 
     assertThat(response, hasStatusCode(SC_INTERNAL_SERVER_ERROR));
-    assertThat(response, body(anyOf(containsString(J8_SSL_ERROR_RESPONSE), containsString(J11_SSL_ERROR_RESPONSE))));
+    assertThat(response, body(anyOf(containsString(J8_262_SSL_ERROR_RESPONSE),
+                                    containsString("No trusted certificate found"),
+                                    containsString(J11_SSL_ERROR_RESPONSE))));
   }
 
   @Test
@@ -85,7 +87,9 @@ public class HttpTlsContextInsecureModeTestCase extends AbstractHttpTlsContextTe
     HttpResponse response = executeGetRequest(defaultModeInvalidUrl);
 
     assertThat(response, hasStatusCode(SC_INTERNAL_SERVER_ERROR));
-    assertThat(response, body(anyOf(containsString(J8_SSL_ERROR_RESPONSE), containsString(J11_SSL_ERROR_RESPONSE))));
+    assertThat(response, body(anyOf(containsString(J8_262_SSL_ERROR_RESPONSE),
+                                    containsString("No trusted certificate found"),
+                                    containsString(J11_SSL_ERROR_RESPONSE))));
   }
 
 }


### PR DESCRIPTION
… for JDK 1.8 (#499)

(cherry picked from commit ef5cc5cff466865aa08ea698711d49d6c7fef72f)