### PR TITLE
MULE-19456: Encode characters from RFC 3986 in HTTP Request Path

### DIFF
--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
@@ -74,7 +74,6 @@ public class HttpRequestOperations implements Initialisable, Disposable {
     map.put(' ', "%20");
     // RFC-3986: delims
     map.put(':', "%3A");
-    map.put('?', "%3F");
     map.put('#', "%24");
     map.put('[', "%5B");
     map.put(']', "%5D");
@@ -82,14 +81,12 @@ public class HttpRequestOperations implements Initialisable, Disposable {
     // RFC-3986: sub-delims
     map.put('!', "%21");
     map.put('$', "%24");
-    map.put('&', "%26");
     map.put('\'', "%27");
     map.put('(', "%28");
     map.put(')', "%29");
     map.put('+', "%2B");
     map.put(',', "%2C");
     map.put(';', "%3B");
-    map.put('=', "%3D");
     RESERVED_CONVERSION = map;
   }
 

--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequestOperations.java
@@ -11,7 +11,6 @@ import static org.mule.extension.http.internal.HttpConnectorConstants.CONNECTOR_
 import static org.mule.extension.http.internal.HttpConnectorConstants.REQUEST;
 import static org.mule.extension.http.internal.HttpConnectorConstants.RESPONSE;
 import static org.mule.runtime.extension.api.annotation.param.MediaType.ANY;
-import static org.mule.runtime.http.api.utils.HttpEncoderDecoderUtils.encodeSpaces;
 
 import org.mule.extension.http.api.HttpResponseAttributes;
 import org.mule.extension.http.api.error.HttpErrorMessageGenerator;
@@ -55,6 +54,7 @@ import org.mule.runtime.http.api.HttpConstants;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -66,6 +66,33 @@ public class HttpRequestOperations implements Initialisable, Disposable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestOperations.class);
   private static final int WAIT_FOR_EVER = MAX_VALUE;
+  private static final Map<Character, String> RESERVED_CONVERSION;
+
+  // We are not currently depending on Guava to be able to use ImmutableMap
+  static {
+    Map<Character, String> map = new HashMap<>();
+    map.put(' ', "%20");
+    // RFC-3986: delims
+    map.put(':', "%3A");
+    map.put('?', "%3F");
+    map.put('#', "%24");
+    map.put('[', "%5B");
+    map.put(']', "%5D");
+    map.put('@', "%40");
+    // RFC-3986: sub-delims
+    map.put('!', "%21");
+    map.put('$', "%24");
+    map.put('&', "%26");
+    map.put('\'', "%27");
+    map.put('(', "%28");
+    map.put(')', "%29");
+    map.put('+', "%2B");
+    map.put(',', "%2C");
+    map.put(';', "%3B");
+    map.put('=', "%3D");
+    RESERVED_CONVERSION = map;
+  }
+
   private SuccessStatusCodeValidator defaultStatusCodeValidator;
   private HttpRequesterRequestBuilder defaultRequestBuilder;
   private HttpRequester httpRequester;
@@ -169,9 +196,24 @@ public class HttpRequestOperations implements Initialisable, Disposable {
     }
   }
 
+  private static String encodeReservedCharacters(String path) {
+    StringBuilder builder = new StringBuilder();
+
+    for (int i = 0; i < path.length(); i++) {
+      char c = path.charAt(i);
+      if (RESERVED_CONVERSION.containsKey(c)) {
+        builder.append(RESERVED_CONVERSION.get(c));
+      } else {
+        builder.append(c);
+      }
+    }
+
+    return builder.toString();
+  }
+
   private String resolveUri(HttpConstants.Protocol scheme, String host, Integer port, String path) {
     // Encode spaces to generate a valid HTTP request.
-    return scheme.getScheme() + "://" + host + ":" + port + encodeSpaces(path);
+    return scheme.getScheme() + "://" + host + ":" + port + encodeReservedCharacters(path);
   }
 
   private int resolveResponseTimeout(Integer responseTimeout) {

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestPathTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestPathTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.http.functional.requester;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.Test;
+import org.mule.runtime.core.api.event.CoreEvent;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
+
+public class HttpRequestPathTestCase extends AbstractHttpRequestTestCase {
+
+  private WithEncodedCharacetersHandler handler = new WithEncodedCharacetersHandler();
+
+  @Override
+  protected String getConfigFile() {
+    return "http-request-path-reserved-encoded-config.xml";
+  }
+
+  @Test
+  public void sendRequestHostWithReservedCharactersInPath() throws Exception {
+    CoreEvent response = flowRunner("hostWithReservedCharactersInPath").withPayload(TEST_PAYLOAD).run();
+    assertThat(response.getMessage(), hasPayload(equalTo((DEFAULT_RESPONSE))));
+    assertThat(handler.uri, is("/some%27%24separators"));
+  }
+
+  @Override
+  protected AbstractHandler createHandler(Server server) {
+    return handler;
+  }
+
+  private class WithEncodedCharacetersHandler extends AbstractHandler {
+
+    public String uri;
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+        throws IOException, ServletException {
+
+      uri = baseRequest.getRequestURI();
+
+      handleRequest(baseRequest, request, response);
+
+      baseRequest.setHandled(true);
+    }
+  }
+
+}

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestPathsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestPathsTestCase.java
@@ -80,7 +80,6 @@ public class HttpRequestPathsTestCase extends AbstractHttpRequestTestCase {
 
   @Test
   public void customPathWithSpaceAndEncodedCharacter() throws Exception {
-    // Spaces should be replaced by "%20", but any other encoded character must not be modified.
     assertRequestUri("requestWithBasePath", "base Path%25", "test Path%25?k1=v%25&k2=v2",
                      "/base%20Path%25/test%20Path%25?k1=v%25&k2=v2");
   }

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestUriParamsTestCase.java
@@ -72,7 +72,7 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
         .withVariable("paramValue", "$a")
         .run();
 
-    assertThat(uri, equalTo("/testPath/$a"));
+    assertThat(uri, equalTo("/testPath/%24a"));
   }
 
   @Test
@@ -84,7 +84,7 @@ public class HttpRequestUriParamsTestCase extends AbstractHttpRequestTestCase {
         .withVariable("paramValue", "a word+here")
         .run();
 
-    assertThat(uri, equalTo("/testPath/a%20word+here"));
+    assertThat(uri, equalTo("/testPath/a%20word%2Bhere"));
   }
 
   @Test

--- a/src/test/resources/http-request-path-reserved-encoded-config.xml
+++ b/src/test/resources/http-request-path-reserved-encoded-config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xsi:schemaLocation="
+               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+               http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <http:request-config name="requestConfig">
+        <http:request-connection host="localhost" port="${httpPort}"/>
+    </http:request-config>
+
+    <flow name="hostWithReservedCharactersInPath">
+        <http:request config-ref="requestConfig" method="POST" path="/some'$separators"/>
+        <object-to-string-transformer />
+    </flow>
+
+</mule>


### PR DESCRIPTION
Clarification: I am adding the code to encode characters in the connector instead of the runtime, because: 
1. If we add it in the runtime (as where `encodeSpaces` is), we could add a new method (we would need a higher min mule version) or use `encodeSpaces`... which would be conceptually incorrect... 
2. So the change of behaviour depends entirely in the connector, rather than the runtime. 

If we have no problem of using `encodeSpaces` and having a different behaviour between mule versions, we could think of having the fix on runtime side (which would _look better_ since we are already depending on Guava and could use `ImmutableMap`)