### PR TITLE
W-11090837: Migrate HttpListenerBindTestCase to unit test

### DIFF
--- a/src/test/java/org/mule/test/http/internal/listener/HttpListenerProviderTestCase.java
+++ b/src/test/java/org/mule/test/http/internal/listener/HttpListenerProviderTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.test.http.internal.listener;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+
+import org.mule.extension.http.internal.listener.HttpListenerProvider;
+import org.mule.runtime.api.exception.DefaultMuleException;
+import org.mule.runtime.http.api.server.HttpServer;
+import org.mule.tck.junit4.AbstractMuleTestCase;
+
+import java.lang.reflect.Field;
+import java.net.BindException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpListenerProviderTestCase extends AbstractMuleTestCase {
+
+  @Mock
+  HttpServer server;
+
+  @InjectMocks
+  HttpListenerProvider httpListenerProvider = new HttpListenerProvider();
+
+  @Test
+  public void testWhenExceptionIsThrownItShouldBeWrappedAsMuleException() throws Exception {
+    HttpListenerProvider.ConnectionParams connectionParams = new HttpListenerProvider.ConnectionParams();
+    Field portField = HttpListenerProvider.ConnectionParams.class.getDeclaredField("port");
+    portField.setAccessible(true);
+    portField.set(connectionParams, 8081);
+
+    Field connectionParamsField = HttpListenerProvider.class.getDeclaredField("connectionParams");
+    connectionParamsField.setAccessible(true);
+    connectionParamsField.set(httpListenerProvider, connectionParams);
+
+    Field configNameField = HttpListenerProvider.class.getDeclaredField("configName");
+    configNameField.setAccessible(true);
+    configNameField.set(httpListenerProvider, "testConfig");
+
+    doThrow(new BindException("Address already in use")).when(server).start();
+
+    try {
+      httpListenerProvider.start();
+      fail("Was expecting start to fail");
+    } catch (DefaultMuleException e) {
+      assertThat(e.getMessage(), is("Could not start HTTP server for 'testConfig' on port 8081: Address already in use"));
+    }
+  }
+}

--- a/src/test/java/org/mule/test/http/internal/listener/HttpListenerProviderTestCase.java
+++ b/src/test/java/org/mule/test/http/internal/listener/HttpListenerProviderTestCase.java
@@ -6,9 +6,9 @@
  */
 package org.mule.test.http.internal.listener;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.mule.test.http.AllureConstants.HttpFeature.HTTP_EXTENSION;
+import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERROR_HANDLING;
+
 import static org.mockito.Mockito.doThrow;
 
 import org.mule.extension.http.internal.listener.HttpListenerProvider;
@@ -19,20 +19,33 @@ import org.mule.tck.junit4.AbstractMuleTestCase;
 import java.lang.reflect.Field;
 import java.net.BindException;
 
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Story;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-@RunWith(MockitoJUnitRunner.class)
+@Feature(HTTP_EXTENSION)
+@Story(ERROR_HANDLING)
+@Issue("W-11090837")
 public class HttpListenerProviderTestCase extends AbstractMuleTestCase {
 
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule();
+
   @Mock
-  HttpServer server;
+  private HttpServer server;
 
   @InjectMocks
-  HttpListenerProvider httpListenerProvider = new HttpListenerProvider();
+  private HttpListenerProvider httpListenerProvider = new HttpListenerProvider();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testWhenExceptionIsThrownItShouldBeWrappedAsMuleException() throws Exception {
@@ -51,11 +64,9 @@ public class HttpListenerProviderTestCase extends AbstractMuleTestCase {
 
     doThrow(new BindException("Address already in use")).when(server).start();
 
-    try {
-      httpListenerProvider.start();
-      fail("Was expecting start to fail");
-    } catch (DefaultMuleException e) {
-      assertThat(e.getMessage(), is("Could not start HTTP server for 'testConfig' on port 8081: Address already in use"));
-    }
+    expectedException.expect(DefaultMuleException.class);
+    expectedException.expectMessage("Could not start HTTP server for 'testConfig' on port 8081: Address already in use");
+
+    httpListenerProvider.start();
   }
 }


### PR DESCRIPTION
The HttpListenerBindTestCase system test was split up into two unit tests:
- One in [mule](https://github.com/mulesoft/mule/pull/11460) which tests that the exception thrown is logged with the correct classloader
- This one which tests that the exception is correctly wrapped as a MuleException

A test in http-service which checks that an exception is thrown if the port is already being used already [exists](https://github.com/mulesoft/mule-http-service/blob/master/src/test/java/org/mule/service/http/impl/functional/server/HttpServerBindTestCase.java) 