### PR TITLE
W-11139894 - HTTP Connector: added support for HTTP 3xx errors. It is required for HTTP Composer Connector in order to identify these kind of errors.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-http-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.7.0-rc1</version>
+    <version>1.8.1-DEV1</version>
 
     <name>HTTP Connector</name>
     <description>A Mule extension that provides HTTP server and client functionality</description>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
     <artifactId>mule-http-connector</artifactId>
     <packaging>mule-extension</packaging>
     <version>1.8.0-SNAPSHOT</version>
-
-
+    
     <name>HTTP Connector</name>
     <description>A Mule extension that provides HTTP server and client functionality</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <artifactId>mule-http-connector</artifactId>
     <packaging>mule-extension</packaging>
     <version>1.8.0-SNAPSHOT</version>
-    
+
     <name>HTTP Connector</name>
     <description>A Mule extension that provides HTTP server and client functionality</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-http-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.8.1-DEV1</version>
+    <version>1.8.0-SNAPSHOT</version>
 
 
     <name>HTTP Connector</name>

--- a/src/main/java/org/mule/extension/http/api/error/HttpError.java
+++ b/src/main/java/org/mule/extension/http/api/error/HttpError.java
@@ -68,7 +68,19 @@ public enum HttpError implements ErrorTypeDefinition<HttpError> {
 
   BAD_GATEWAY,
 
-  GATEWAY_TIMEOUT;
+  MULTI_STATUS,
+
+  GATEWAY_TIMEOUT,
+
+  MULTIPLE_CHOICES,
+
+  MOVED_PERMANENTLY,
+
+  MOVED_TEMPORARILY,
+
+  SEE_OTHER,
+
+  NOT_MODIFIED;
 
   private static Set<ErrorTypeDefinition> httpRequestOperationErrors;
 
@@ -92,6 +104,11 @@ public enum HttpError implements ErrorTypeDefinition<HttpError> {
     errors.add(SERVICE_UNAVAILABLE);
     errors.add(BAD_GATEWAY);
     errors.add(GATEWAY_TIMEOUT);
+    errors.add(MULTIPLE_CHOICES);
+    errors.add(MOVED_PERMANENTLY);
+    errors.add(MOVED_TEMPORARILY);
+    errors.add(SEE_OTHER);
+    errors.add(NOT_MODIFIED);
 
     httpRequestOperationErrors = unmodifiableSet(errors);
   }

--- a/src/main/java/org/mule/extension/http/api/error/HttpError.java
+++ b/src/main/java/org/mule/extension/http/api/error/HttpError.java
@@ -68,8 +68,6 @@ public enum HttpError implements ErrorTypeDefinition<HttpError> {
 
   BAD_GATEWAY,
 
-  MULTI_STATUS,
-
   GATEWAY_TIMEOUT,
 
   MULTIPLE_CHOICES,

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
@@ -32,7 +32,6 @@ import static org.mule.runtime.http.api.HttpConstants.HttpStatus.MULTIPLE_CHOICE
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.SEE_OTHER;
 import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_MODIFIED;
 
-
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERRORS;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERROR_HANDLING;
 

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
@@ -13,7 +13,26 @@ import static org.junit.Assert.assertThat;
 import static org.mule.extension.http.internal.listener.HttpListener.HTTP_NAMESPACE;
 import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
 import static org.mule.runtime.extension.api.error.MuleErrors.ANY;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.*;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.UNAUTHORIZED;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.FORBIDDEN;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_FOUND;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.METHOD_NOT_ALLOWED;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_ACCEPTABLE;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.TOO_MANY_REQUESTS;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.SERVICE_UNAVAILABLE;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.EXPECTATION_FAILED;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.GATEWAY_TIMEOUT;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.BAD_GATEWAY;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.MOVED_PERMANENTLY;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.MOVED_TEMPORARILY;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.MULTIPLE_CHOICES;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.SEE_OTHER;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_MODIFIED;
+
+
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERRORS;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERROR_HANDLING;
 
@@ -195,12 +214,12 @@ public class HttpRequestErrorHandlingTestCase extends AbstractHttpRequestTestCas
     return getErrorMessage(customMessage, httpPort);
   }
 
-  void verifyErrorWhenReceiving(HttpStatus status, String expectedMessage) throws Exception {
+  private void verifyErrorWhenReceiving(HttpStatus status, String expectedMessage) throws Exception {
     verifyErrorWhenReceiving(status, format("%s %s", status.getStatusCode(), status.getReasonPhrase()), status.name(),
                              getErrorMessage(expectedMessage));
   }
 
-  void verifyErrorWhenReceiving(HttpStatus status, Object expectedResult, String expectedError, String expectedMessage)
+  private void verifyErrorWhenReceiving(HttpStatus status, Object expectedResult, String expectedError, String expectedMessage)
       throws Exception {
     serverStatus = status.getStatusCode();
     // Hit flow with error handler

--- a/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
+++ b/src/test/java/org/mule/test/http/functional/requester/HttpRequestErrorHandlingTestCase.java
@@ -13,19 +13,7 @@ import static org.junit.Assert.assertThat;
 import static org.mule.extension.http.internal.listener.HttpListener.HTTP_NAMESPACE;
 import static org.mule.functional.junit4.matchers.MessageMatchers.hasPayload;
 import static org.mule.runtime.extension.api.error.MuleErrors.ANY;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.BAD_GATEWAY;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.BAD_REQUEST;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.EXPECTATION_FAILED;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.FORBIDDEN;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.GATEWAY_TIMEOUT;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.METHOD_NOT_ALLOWED;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_ACCEPTABLE;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.NOT_FOUND;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.SERVICE_UNAVAILABLE;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.TOO_MANY_REQUESTS;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.UNAUTHORIZED;
-import static org.mule.runtime.http.api.HttpConstants.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+import static org.mule.runtime.http.api.HttpConstants.HttpStatus.*;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERRORS;
 import static org.mule.test.http.AllureConstants.HttpFeature.HttpStory.ERROR_HANDLING;
 
@@ -39,11 +27,14 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mule.extension.http.api.HttpResponseAttributes;
 import org.mule.extension.http.api.error.HttpError;
 import org.mule.functional.api.exception.ExpectedError;
 import org.mule.functional.api.flow.FlowRunner;
+import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.util.concurrent.Latch;
 import org.mule.runtime.core.api.event.CoreEvent;
+import org.mule.runtime.core.internal.streaming.bytes.ManagedCursorStreamProvider;
 import org.mule.runtime.http.api.HttpConstants.HttpStatus;
 import org.mule.tck.junit4.rule.DynamicPort;
 
@@ -170,6 +161,32 @@ public class HttpRequestErrorHandlingTestCase extends AbstractHttpRequestTestCas
                hasPayload(equalTo(DEFAULT_RESPONSE)));
   }
 
+  @Test
+  public void movedPermanently() throws Exception {
+    verifyErrorWhenRedirect(MOVED_PERMANENTLY, "301 Moved Permanently");
+  }
+
+  @Test
+  public void movedTemporarily() throws Exception {
+    verifyErrorWhenRedirect(MOVED_TEMPORARILY, "302 Found", MOVED_TEMPORARILY.name(),
+                            getErrorMessage("302 Moved Temporarily"));
+  }
+
+  @Test
+  public void multipleChoices() throws Exception {
+    verifyErrorWhenRedirect(MULTIPLE_CHOICES, "300 Multiple Choices");
+  }
+
+  @Test
+  public void seeOther() throws Exception {
+    verifyErrorWhenRedirect(SEE_OTHER, "303 See Other");
+  }
+
+  @Test
+  public void notModified() throws Exception {
+    verifyErrorWhenRedirect(NOT_MODIFIED, "304 Not Modified");
+  }
+
   private String getErrorMessage(String customMessage, DynamicPort port) {
     return format("HTTP GET on resource 'http://localhost:%s/testPath' failed%s.", port.getValue(), customMessage);
   }
@@ -195,6 +212,20 @@ public class HttpRequestErrorHandlingTestCase extends AbstractHttpRequestTestCas
     }
     this.expectedError.expectMessage(is(expectedMessage));
     getFlowRunner("unhandled", httpPort.getNumber()).run();
+  }
+
+  void verifyErrorWhenRedirect(HttpStatus status, String expectedMessage) throws Exception {
+    verifyErrorWhenRedirect(status, format("%s %s", status.getStatusCode(), status.getReasonPhrase()), status.name(),
+                            getErrorMessage(expectedMessage));
+  }
+
+  void verifyErrorWhenRedirect(HttpStatus status, Object expectedResult, String expectedError, String expectedMessage)
+      throws Exception {
+    serverStatus = status.getStatusCode();
+    // Hit flow with error handler
+    CoreEvent result = getFlowRunner("redirect", httpPort.getNumber()).run();
+    HttpResponseAttributes attributes = (HttpResponseAttributes) result.getMessage().getAttributes().getValue();
+    assertThat(attributes.getStatusCode() + " " + attributes.getReasonPhrase(), is(expectedResult));
   }
 
   private FlowRunner getFlowRunner(String flowName, int port) {

--- a/src/test/resources/http-request-errors-config.xml
+++ b/src/test/resources/http-request-errors-config.xml
@@ -81,4 +81,16 @@
         </error-handler>
     </flow>
 
+    <flow name="redirect" >
+        <http:request config-ref="simpleConfig" path="testPath" responseTimeout="1000" followRedirects="false">
+            <http:headers>#[{'Content-Type': 'application/xml'}]</http:headers>
+        </http:request>
+        <error-handler>
+            <on-error-continue>
+                <logger level="WARN" message="#[error.errorMessage.payload]"/>
+                <set-payload value="#[error.errorMessage.payload]"/>
+            </on-error-continue>
+        </error-handler>
+    </flow>
+
 </mule>


### PR DESCRIPTION
Composer needs to identify the HTTP 301 error code returned when it tries to make a connection. 