### PR TITLE
upgrade apache common text version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <javaxMailVersion>1.4.3</javaxMailVersion>
         <jettyVersion>9.0.7.v20131107</jettyVersion>
 
-        <commonsTextVersion>1.9</commonsTextVersion>
+        <commonsTextVersion>1.10.0</commonsTextVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 
         <muleSocketsConnectorVersion>1.2.2</muleSocketsConnectorVersion>


### PR DESCRIPTION
https://mvnrepository.com/artifact/org.apache.commons/commons-text

having vulranelbility , it need to be upgraded to 1.10.0
https://nvd.nist.gov/vuln/detail/CVE-2022-42889