### PR TITLE
upgrade apache common text version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <javaxMailVersion>1.4.3</javaxMailVersion>
         <jettyVersion>9.0.7.v20131107</jettyVersion>
 
-        <commonsTextVersion>1.9</commonsTextVersion>
+        <commonsTextVersion>1.10.0</commonsTextVersion>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 
         <muleSocketsConnectorVersion>1.2.2</muleSocketsConnectorVersion>


### PR DESCRIPTION
Fix for vulraneability 

https://nakedsecurity.sophos.com/2022/10/18/dangerous-hole-in-apache-commons-text-like-log4shell-all-over-again/