### PR TITLE
W-12361924: Make HTTP Connector MUnit tests run with latest runtime by default (#669)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,9 +42,9 @@
         <!-- Remove when a new parent version with MTF is available -->
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
-        <munit.extensions.maven.plugin.version>1.1.1</munit.extensions.maven.plugin.version>
-        <munit.version>2.2.4</munit.version>
-        <mtf-tools.version>1.0.0</mtf-tools.version>
+        <munit.extensions.maven.plugin.version>1.1.2</munit.extensions.maven.plugin.version>
+        <munit.version>2.3.14</munit.version>
+        <mtf-tools.version>1.1.2</mtf-tools.version>
         <mavenResources.version>3.0.2</mavenResources.version>
     </properties>
 
@@ -104,10 +104,19 @@
                             -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco.exec
                         </argLine>
                     </argLines>
+                    <!-- Configuration for local builds, in Jenkins we configure this via command line arguments -->
                     <runtimeConfiguration>
+                        <!-- Compatibility with the minMuleVersion -->
+                        <additionalRuntimes>
+                            <additionalRuntime>MULE_EE:4.1.1</additionalRuntime>
+                        </additionalRuntimes>
+
+                        <!-- Versions with support and snapshots -->
                         <discoverRuntimes>
-                            <product>ALL</product>
+                            <product>EE</product>
+                            <minMuleVersion>4.4.0</minMuleVersion>
                             <includeSnapshots>true</includeSnapshots>
+                            <latestPatches>true</latestPatches>
                         </discoverRuntimes>
                     </runtimeConfiguration>
                 </configuration>

--- a/src/test/munit/header-too-long/header-too-long-test-case.xml
+++ b/src/test/munit/header-too-long/header-too-long-test-case.xml
@@ -26,7 +26,7 @@
 
     <munit:test name="header-too-long-test" description="Test" ignore="#[Munit::muleVersionEqualTo('4.3.0')]">
         <munit:enable-flow-sources>
-            <munit:enable-flow-source value="ListenerFlow" />
+            <munit:enable-flow-source value="HeaderTooLongListenerFlow" />
         </munit:enable-flow-sources>
         <munit:execution >
             <try>
@@ -49,7 +49,7 @@ import * from dw::core::Strings
             <munit-tools:assert-that is="#[MunitTools::containsString('failed with status code 413')]" expression="#[vars.errorMessage]"/>
         </munit:validation>
     </munit:test>
-    <flow name="ListenerFlow" >
+    <flow name="HeaderTooLongListenerFlow" >
         <http:listener config-ref="HttpListenerConfig" path="*" responseStreamingMode="NEVER">
             <non-repeatable-stream />
         </http:listener>

--- a/src/test/munit/selectors-non-blocking/selectors-non-blocking.xml
+++ b/src/test/munit/selectors-non-blocking/selectors-non-blocking.xml
@@ -16,11 +16,11 @@
 
     <munit:dynamic-port propertyName="dynamic.port"/>
 
-    <http:listener-config name="listenerConfig" doc:name="HTTP Listener config" >
+    <http:listener-config name="selectorsNonBlockingListenerConfig" doc:name="HTTP Listener config" >
         <http:listener-connection host="0.0.0.0" port="${dynamic.port}" />
     </http:listener-config>
 
-    <http:request-config name="requestConfig" >
+    <http:request-config name="selectorsNonBlockingRequestConfig" >
         <http:request-connection host="localhost" port="${dynamic.port}"/>
     </http:request-config>
 
@@ -33,7 +33,7 @@
                 <java:args><![CDATA[#[{arg0: ${dynamic.port}}]]]></java:args>
             </java:invoke-static>
 
-            <http:request method="GET" doc:name="Test Request" path="/test" config-ref="requestConfig"/>
+            <http:request method="GET" doc:name="Test Request" path="/test" config-ref="selectorsNonBlockingRequestConfig"/>
             <set-variable value="#[payload as String]" doc:name="Set Variable" variableName="test_response"/>
 
             <java:invoke-static doc:name="Close sockets" class="org.mule.test.SlowRequester" method="closeSockets()"/>
@@ -44,7 +44,7 @@
     </munit:test>
     
     <flow name="TestFlow" >
-        <http:listener doc:name="Test" path="/test" config-ref="listenerConfig" />
+        <http:listener doc:name="Test" path="/test" config-ref="selectorsNonBlockingListenerConfig" />
         <logger />
         <set-payload value='#["Test payload"]' />
     </flow>

--- a/src/test/munit/url-too-long/url-too-long-test-case.xml
+++ b/src/test/munit/url-too-long/url-too-long-test-case.xml
@@ -26,7 +26,7 @@
 
     <munit:test name="url-too-long-test" description="Test" ignore="#[Munit::muleVersionEqualTo('4.3.0')]">
         <munit:enable-flow-sources>
-            <munit:enable-flow-source value="ListenerFlow" />
+            <munit:enable-flow-source value="UrlTooLongListenerFlow" />
         </munit:enable-flow-sources>
         <munit:execution >
             <try>


### PR DESCRIPTION
(cherry picked from commit 47e2b1e5cb0cdb9383c85770a62ae289ebe4e39c)