### PR TITLE
Add Headers as Attributes for Otel traces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-http-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.8.0-SNAPSHOT</version>
+    <version>1.8.1-SNAPSHOT</version>
 
     <name>HTTP Connector</name>
     <description>A Mule extension that provides HTTP server and client functionality</description>

--- a/src/main/java/org/mule/extension/http/api/listener/server/HttpListenerConfig.java
+++ b/src/main/java/org/mule/extension/http/api/listener/server/HttpListenerConfig.java
@@ -9,6 +9,7 @@ package org.mule.extension.http.api.listener.server;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
+import static org.mule.runtime.api.meta.ExpressionSupport.SUPPORTED;
 import static org.mule.runtime.api.util.Preconditions.checkArgument;
 
 import org.mule.extension.http.api.listener.headers.HttpHeadersException;
@@ -66,12 +67,25 @@ public class HttpListenerConfig implements Initialisable {
   @Expression(NOT_SUPPORTED)
   private boolean rejectInvalidTransferEncoding;
 
+  /**
+   * W-12558102
+   * Indicates what headers should not be exported as attributes when generating Open Telemetry traces. By default, common headers associated with credentials are skipped.
+   *
+   * @since 1.8.0
+   */
+  @Parameter
+  @Optional(defaultValue = "client_id, client_secret, Authorization")
+  @Expression(SUPPORTED)
+  private String skipHeadersOnTracing;
+
   private HttpHeadersValidator httpHeaderValidators;
 
   @Override
   public void initialise() throws InitialisationException {
     basePath = sanitizePathWithStartSlash(this.basePath);
     httpHeaderValidators = new InvalidTransferEncodingValidator(rejectInvalidTransferEncoding);
+    //W-12558102
+    skipHeadersOnTracing = this.skipHeadersOnTracing;
   }
 
   public ListenerPath getFullListenerPath(String listenerPath) {
@@ -98,5 +112,10 @@ public class HttpListenerConfig implements Initialisable {
    */
   public void validateHeaders(MultiMap<String, String> headers) throws HttpHeadersException {
     httpHeaderValidators.validateHeaders(headers);
+  }
+
+  //W-12558102
+  public String getSkipHeadersOnTracing() {
+    return skipHeadersOnTracing;
   }
 }

--- a/src/main/java/org/mule/extension/http/internal/listener/HttpListener.java
+++ b/src/main/java/org/mule/extension/http/internal/listener/HttpListener.java
@@ -441,7 +441,7 @@ public class HttpListener extends Source<InputStream, HttpRequestAttributes> {
                 forwardCompatibilityHelper.get().getDistributedTraceContextManager(context);
             distributedTraceContextManager.setRemoteTraceContextMap(headers);
             getHttpListenerCurrentSpanCustomizer(result.getAttributes().get(), server.getServerAddress().getIp(),
-                                                 server.getServerAddress().getPort())
+                                                 server.getServerAddress().getPort(), config.getSkipHeadersOnTracing())
                                                      .customizeSpan(distributedTraceContextManager);
           }
 

--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequester.java
@@ -147,7 +147,8 @@ public class HttpRequester {
                                                           authentication, injectedHeaders, requestCreator,
                                                           distributedTraceContextManager);
 
-    getHttpRequesterCurrentSpanCustomizer(httpRequester).customizeSpan(distributedTraceContextManager);
+    getHttpRequesterCurrentSpanCustomizer(httpRequester, config.getSkipHeadersOnTracing())
+        .customizeSpan(distributedTraceContextManager);
 
     doRequestWithRetry(client, config, uri, method, streamingMode, sendBodyMode, followRedirects, authentication, resolvedTimeout,
                        responseValidator, transformationService, requestCreator, checkRetry, muleContext, scheduler,

--- a/src/main/java/org/mule/extension/http/internal/request/HttpRequesterConfig.java
+++ b/src/main/java/org/mule/extension/http/internal/request/HttpRequesterConfig.java
@@ -50,6 +50,11 @@ public class HttpRequesterConfig implements Initialisable, HttpRequesterCookieCo
   @Placement(order = 3)
   private ResponseSettings responseSettings;
 
+  //W-12558102
+  @ParameterGroup(name = "Tracing Settings")
+  @Placement(order = 4)
+  private TracingSettings tracingSettings;
+
   @Inject
   private MuleContext muleContext;
   private CookieManager cookieManager;
@@ -93,6 +98,11 @@ public class HttpRequesterConfig implements Initialisable, HttpRequesterCookieCo
     return responseSettings.getResponseTimeout();
   }
 
+  //W-12558102
+  public String getSkipHeadersOnTracing() {
+    return tracingSettings.getSkipHeadersOnTracing();
+  }
+
   @Override
   public boolean isEnableCookies() {
     return requestSettings.isEnableCookies();
@@ -116,6 +126,8 @@ public class HttpRequesterConfig implements Initialisable, HttpRequesterCookieCo
     private RequestUrlConfiguration urlConfiguration;
     private RequestSettings requestSettings;
     private ResponseSettings responseSettings;
+    //W-12558102
+    private TracingSettings tracingSettings;
     private MuleContext muleContext;
 
     private Builder() {}
@@ -135,6 +147,12 @@ public class HttpRequesterConfig implements Initialisable, HttpRequesterCookieCo
       return this;
     }
 
+    //W-12558102
+    public Builder withTracingSettings(TracingSettings tracingSettings) {
+      this.tracingSettings = tracingSettings;
+      return this;
+    }
+
     public Builder withMuleContext(MuleContext muleContext) {
       this.muleContext = muleContext;
       return this;
@@ -149,6 +167,8 @@ public class HttpRequesterConfig implements Initialisable, HttpRequesterCookieCo
       config.urlConfiguration = this.urlConfiguration;
       config.requestSettings = this.requestSettings;
       config.responseSettings = this.responseSettings;
+      //W-12558102
+      config.tracingSettings = this.tracingSettings;
       config.muleContext = this.muleContext;
       return config;
     }

--- a/src/main/java/org/mule/extension/http/internal/request/TracingSettings.java
+++ b/src/main/java/org/mule/extension/http/internal/request/TracingSettings.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.extension.http.internal.request;
+
+import static org.mule.runtime.api.meta.ExpressionSupport.SUPPORTED;
+
+import org.mule.runtime.extension.api.annotation.Expression;
+import org.mule.runtime.extension.api.annotation.param.Optional;
+import org.mule.runtime.extension.api.annotation.param.Parameter;
+
+/**
+ * Groups parameters which configure how a request is traced
+ *
+ * @since 1.0
+ */
+public final class TracingSettings {
+
+  /**
+   * Indicates what headers should not be exported as attributes when generating Open Telemetry traces. By default, common headers associated with credentials are skipped.
+   *
+   * @since 1.8.0
+   */
+  @Parameter
+  @Optional(defaultValue = "client_id, client_secret, Authorization")
+  @Expression(SUPPORTED)
+  private String skipHeadersOnTracing;
+
+  public String getSkipHeadersOnTracing() {
+    return skipHeadersOnTracing;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private String skipHeadersOnTracing;
+
+    public Builder withFollowRedirects(String skipHeadersOnTracing) {
+      this.skipHeadersOnTracing = skipHeadersOnTracing;
+      return this;
+    }
+
+    public TracingSettings build() {
+      TracingSettings settings = new TracingSettings();
+      settings.skipHeadersOnTracing = this.skipHeadersOnTracing;
+      return settings;
+    }
+  }
+}

--- a/src/main/java/org/mule/extension/http/internal/request/profiling/tracing/HttpCurrentSpanCustomizer.java
+++ b/src/main/java/org/mule/extension/http/internal/request/profiling/tracing/HttpCurrentSpanCustomizer.java
@@ -10,6 +10,7 @@ package org.mule.extension.http.internal.request.profiling.tracing;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.mule.sdk.api.runtime.source.DistributedTraceContextManager;
+import org.mule.runtime.api.util.MultiMap;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -78,4 +79,10 @@ public abstract class HttpCurrentSpanCustomizer {
    * @return the span kind
    */
   protected abstract String getSpanKind();
+
+  /**
+   * W-12558102
+   * @return the headers for the http span.
+   */
+  public abstract MultiMap<String, String> getHeaders();
 }

--- a/src/test/java/org/mule/test/http/internal/profiling/tracing/HttpCurrentSpanCustomizerTestCase.java
+++ b/src/test/java/org/mule/test/http/internal/profiling/tracing/HttpCurrentSpanCustomizerTestCase.java
@@ -60,6 +60,8 @@ public class HttpCurrentSpanCustomizerTestCase {
   public static final String EXPECTED_PEER_NAME = "www.expectedhost.com";
   public static final int TEST_PORT = 8080;
   public static final String EXPECTED_SCHEME = HTTPS;
+  //W-  gp
+  public static final String SKIP_HEADERS_ATTRIBUTES = "";
 
   @Test
   @Description("The listener span customizer informs the distributed trace context manager the correct attributes/name")
@@ -74,7 +76,8 @@ public class HttpCurrentSpanCustomizerTestCase {
     when(headers.get(USER_AGENT)).thenReturn(EXPECTED_USER_AGENT);
     when(attributes.getLocalAddress()).thenReturn(LOCAL_ADDRESS);
 
-    HttpCurrentSpanCustomizer currentSpanCustomizer = getHttpListenerCurrentSpanCustomizer(attributes, TEST_HOST, TEST_PORT);
+    HttpCurrentSpanCustomizer currentSpanCustomizer =
+        getHttpListenerCurrentSpanCustomizer(attributes, TEST_HOST, TEST_PORT, SKIP_HEADERS_ATTRIBUTES);
     DistributedTraceContextManager distributedTraceContextManager = mock(DistributedTraceContextManager.class);
     currentSpanCustomizer.customizeSpan(distributedTraceContextManager);
 
@@ -99,7 +102,8 @@ public class HttpCurrentSpanCustomizerTestCase {
     when(httpRequest.getUri()).thenReturn(uri);
     when(httpRequest.getProtocol()).thenReturn(HTTP_1_1);
 
-    HttpCurrentSpanCustomizer httpCurrentSpanCustomizer = getHttpRequesterCurrentSpanCustomizer(httpRequest);
+    HttpCurrentSpanCustomizer httpCurrentSpanCustomizer =
+        getHttpRequesterCurrentSpanCustomizer(httpRequest, SKIP_HEADERS_ATTRIBUTES);
     httpCurrentSpanCustomizer.customizeSpan(distributedTraceContextManager);
 
     verify(distributedTraceContextManager).setCurrentSpanName(EXPECTED_SPAN_NAME);


### PR DESCRIPTION
GUS Associated: [W-12558102](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001LPLeGYAX/view)

This commit adds the possibility that the headers processed by the HTTP listener and by the HTTP requester are added as attributes of the spans initialized during the Otel implementation. This new feature takes into account the option of omitting headers that you do not want to register by using a property that is configured at the config element level of both components. An example of use is as follows:

- HTTP Listener

`<http:listener-config name="HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="f83efe45-479a-498f-adc1-8848f33ed380" skipHeadersOnTracing="client_id, client_secret">`

- HTTP Requester

`<http:request-config name="HTTP_Request_configuration" doc:name="HTTP Request configuration" doc:id="3a18fe34-e53b-4ca4-80e2-229cb386f1bb" preserveHeadersCase="true" skipHeadersOnTracing="client_id, client_secret">`

- Example cUrl request
`curl --location --request GET 'localhost:8081/test' \
--header 'X-Example-Header: Test' \
--header 'client_id: thisIsAnExampleClientID' \
--header 'client_secret: thisIsAnExampleClientSecret'`

The final result is the following:

- **Before the change** - Attributes registered for the example call
   - Listener:
   <img width="325" alt="image" src="https://user-images.githubusercontent.com/50634447/219456604-0093294f-0dc3-4f0d-934a-2fd097e1936e.png">
   
   - Requester:
   <img width="679" alt="image" src="https://user-images.githubusercontent.com/50634447/219457345-c398bffa-4101-4095-b59e-5f90cb930f1f.png">

- **After the change** - Attributes registered for the example call
   - Listener
     <img width="752" alt="image" src="https://user-images.githubusercontent.com/50634447/219456848-69c58c5a-7269-4b4d-bc7d-87c78000f511.png">

   - Requester 
     <img width="671" alt="image" src="https://user-images.githubusercontent.com/50634447/219457848-618ecbbe-a914-467d-9bb8-5d4bc7b47635.png">
 
