### PR TITLE
W-14728849: Add processAllModules to aggregator pom's versions-maven-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
                         <parameters>true</parameters>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <configuration>
+                        <processAllModules>true</processAllModules>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This fixes an issue where `mvn versions:set -DnewVersion=X.Y.Z` didn't update the extension's version, because it doesn't have the aggregator pom as parent