### PR TITLE
W-16911643: Fix HttpListenerHeaderSizeTestCase

### DIFF
--- a/functional-tests/http/src/test/java/org/mule/test/http/functional/listener/HttpListenerHeaderSizeTestCase.java
+++ b/functional-tests/http/src/test/java/org/mule/test/http/functional/listener/HttpListenerHeaderSizeTestCase.java
@@ -32,6 +32,11 @@ public class HttpListenerHeaderSizeTestCase extends AbstractHttpTestCase {
   @Rule
   public SystemProperty maxHeaderSectionSizeSystemProperty =
       new SystemProperty(SYSTEM_PROPERTY_PREFIX + "http.headerSectionSize", "10000");
+
+  @Rule
+  public SystemProperty maxInitialLineLengthSystemProperty =
+      new SystemProperty(SYSTEM_PROPERTY_PREFIX + "http.initialLineLength", "10000");
+
   @Rule
   public DynamicPort dynamicPort = new DynamicPort("port");
 


### PR DESCRIPTION
In Netty, we set limits separately for the initial line (maxInitialLineLength) and the headers (maxHeaderSize). However, Grizzly uses a single limit for the combined size of the initial line and headers. Changes were introduced to align with the Grizzly implementation.